### PR TITLE
Remove forever and fix dependency problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "scripts": {
     "compile": "grunt generate-assets",
     "clean": "grunt clean",
-    "start": "node_modules/forever/bin/forever --minUptime 1000 --spinSleepTime 500 start.js",
-    "stop": "node_modules/forever/bin/forever stop start.js",
+    "start": "node ./start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "watch-live-reload": "./node_modules/.bin/grunt watch",
     "lint": "./node_modules/.bin/standard",
@@ -44,7 +43,6 @@
     "cluster": "0.7.x",
     "compression": "1.6.x",
     "express": "4.15.x",
-    "forever": "0.15.x",
     "govuk-elements-sass": "3.1.0",
     "govuk_frontend_toolkit": "6.0.x",
     "govuk_template_mustache": "0.22.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "requestretry": "^1.12.0",
     "serve-favicon": "2.4.5",
     "staticify": "0.0.8",
-    "throng": "4.0.x"
+    "throng": "4.0.x",
+    "pino": "4.10.1"
   },
   "devDependencies": {
     "@pact-foundation/pact-node": "4.6.0",

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const express = require('express')
 const favicon = require('serve-favicon')
 const bodyParser = require('body-parser')
 const i18n = require('i18n')
-const logger = require('winston')
+const logger = require('pino')()
 const loggingMiddleware = require('morgan')
 const argv = require('minimist')(process.argv.slice(2))
 const staticify = require('staticify')(path.join(__dirname, 'public'))
@@ -17,11 +17,6 @@ const expressApp = express()
 
 function initialiseGlobalMiddleware (app) {
   app.set('settings', {getVersionedPath: staticify.getVersionedPath})
-  logger.stream = {
-    write: function (message) {
-      logger.info(message)
-    }
-  }
   app.use(favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images', 'favicon.ico')))
   app.use(compression())
   app.use(staticify.middleware)
@@ -73,7 +68,7 @@ function initialiseRoutes (app) {
 function listen () {
   const app = initialise()
   app.listen(port)
-  logger.log('Listening on port ' + port)
+  logger.info('Listening on port ' + port)
 }
 
 /**

--- a/start.js
+++ b/start.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const fs = require('fs')
-const logger = require('winston')
+const logger = require('pino')()
 const throng = require('throng')
 const server = require('./server')
 const environment = require('./app/services/environment')


### PR DESCRIPTION
## WHAT

1. Remove `forever`

We don't need `forever` when running in Amazon EC2 Container Service.

Also, `forever@0.15.3` depends on `timespan` which has "Regular Expression Denial of Service (ReDoS)" vulnerability: https://snyk.io/vuln/npm:timespan:20170907

There is an issue open for `timespan` here: indexzero/TimeSpan.js#10 (not fixed).

2. Fix dependency problem

We were referencing non-existing "winston" dependency.
Added "pino" as a new logger.