### PR TITLE
PP-3106 Scaffolding for minimum viable payment journey

### DIFF
--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -1,5 +1,16 @@
 'use strict'
 
 module.exports = (req, res) => {
-  res.render('app/confirmation/get')
+  const confirmationDetails = req.session.confirmationDetails
+  const paymentRequest = req.session.paymentRequest
+  const params = {
+    paymentRequestExternalId: req.params.paymentRequestExternalId,
+    accountHolderName: confirmationDetails.accountHolderName,
+    accountNumber: confirmationDetails.accountNumber,
+    sortCode: confirmationDetails.sortCode,
+    returnUrl: paymentRequest.returnUrl,
+    description: paymentRequest.description,
+    amount: paymentRequest.amount
+  }
+  res.render('app/confirmation/get', params)
 }

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -1,16 +1,66 @@
 'use strict'
 
 // npm dependencies
+const chai = require('chai')
 const supertest = require('supertest')
+const cheerio = require('cheerio')
+const expect = chai.expect
 
 // Local dependencies
 const getApp = require('../../server').getApp
-
-describe('GET /confirmation page', function () {
-  it('should return HTTP 200 status', function (done) {
+const setup = require('../setup')
+const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+const {CookieBuilder} = require('../../test/test_helpers/cookie-helper')
+describe('confirmation get controller', function () {
+  let response, $
+  let paymentRequestExternalId = 'sdfihsdufh2e'
+  let accountName = 'bla'
+  let sortCode = '123456'
+  let accountNumber = '12345678'
+  let description = 'this is a description'
+  let amount = 1000
+  before(done => {
+    let paymentRequest = paymentFixtures.validPaymentRequest({
+      external_id: paymentRequestExternalId,
+      description: description,
+      amount: amount
+    })
+    let payer = paymentFixtures.validPayer({
+      account_holder_name: accountName,
+      sort_code: sortCode,
+      account_number: accountNumber
+    })
+    const cookieHeader = new CookieBuilder()
+      .withPaymentRequest(paymentRequest)
+      .withConfirmationDetails(payer)
+      .build()
     supertest(getApp())
-      .get('/confirmation')
-      .expect(200)
-      .end(done)
+      .get(`/confirmation/${paymentRequestExternalId}`)
+      .set('cookie', cookieHeader)
+      .end((err, res) => {
+        response = res
+        $ = cheerio.load(res.text)
+        // sessionCookie = decryptCookie(res.header['set-cookie']).session
+        done(err)
+      })
+  })
+  it('should return HTTP 200 status', () => {
+    expect(response.statusCode).to.equal(200)
+  })
+  it('should display the confirmation page with a back link to the setup page', () => {
+    let url = setup.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
+    expect($('.link-back').attr('href')).to.equal(url)
+  })
+  it('should display the confirmation page with the payer details', () => {
+    expect($('#account-holder-name').text()).to.equal(accountName)
+    expect($('#sort-code').text()).to.equal(sortCode)
+    expect($('#account-number').text()).to.equal(accountNumber)
+  })
+  it('should display the enter confirmation page with correct description and amount', () => {
+    expect($(`#payment-description`).text()).to.equal(description)
+    expect($(`#amount`).text()).to.equal(`£10.00`)
+  })
+  it('should display the enter confirmation page with bank statement description', () => {
+    expect($(`#bank-statement-description`).text()).to.equal(`'${description}'`)
   })
 })

--- a/app/confirmation/get.njk
+++ b/app/confirmation/get.njk
@@ -7,7 +7,7 @@
 {% block content %}
   <main id="content" role="main">
     <div>
-      <a href="/setup" class="link-back">Back</a>
+      <a href="/setup/{{paymentRequestExternalId}}" class="link-back">Back</a>
     </div>
     <div class="grid-row relative">
       <div class="column-two-thirds">
@@ -16,31 +16,33 @@
           <tbody>
           <tr>
             <td>Name on the account:</td>
-            <td>Alex Smith</td>
+            <td id="account-holder-name">{{accountHolderName}}</td>
           </tr>
           <tr>
             <td>Sort code:</td>
-            <td>400500</td>
+            <td id="sort-code">{{sortCode}}</td>
           </tr>
           <tr>
             <td>Account number:</td>
-            <td>12345678</td>
+            <td id="account-number">{{accountNumber}}</td>
           </tr>
           </tbody>
         </table>
-        <div class="panel panel-border-wide bank-statment-message">
-          <p><span class="bold-small">‘Thames-Fishing-Permit’</span> will appear on your bank statement</p>
+        <div class="panel panel-border-wide bank-statement-message">
+          <p><span class="bold-small" id="bank-statement-description">'{{description}}'</span> will appear on your bank statement</p>
         </div>
-        <div class="form-group">
-          <a href="#" class="button">Confirm payment</a>
-          <a class="cancel-link" href="/setup">Cancel payment</a>
-        </div>
+        <form class="form" method="POST" action="/confirmation/{{paymentRequestExternalId}}">
+          <div class="form-group">
+            <button type="submit" id="submit-direct-debit" class="button">Confirm payment</button>
+            <a class="cancel-link" href="/setup/{{paymentRequestExternalId}}">Cancel payment</a>
+          </div>
+        </form>
       </div>
       <aside class="payment-summary">
         <div class="payment-summary__inner js-stick-at-top-when-scrolling">
           <h2 class="heading-medium">Payment summary</h2>
-          <p class="payment-summary__description">Lock and Weir Fishing Permit – River Thames</p>
-          <p class="payment-summary__description">Total amount: <span class="payment-summary__amount">£31.00</span>
+          <p class="payment-summary__description" id="payment-description">{{description}}</p>
+          <p class="payment-summary__description">Total amount: <span class="payment-summary__amount" id="amount">£{{amount}}</span>
         </div>
       </aside>
     </div>

--- a/app/confirmation/index.js
+++ b/app/confirmation/index.js
@@ -5,16 +5,18 @@ const express = require('express')
 
 // Local dependencies
 const getController = require('./get.controller')
+const postController = require('./post.controller')
 
 // Initialisation
 const router = express.Router()
-const indexPath = '/confirmation'
+const indexPath = '/confirmation/:paymentRequestExternalId'
 const paths = {
   index: indexPath
 }
 
 // Routing
 router.get(paths.index, getController)
+router.post(paths.index, postController)
 
 // Export
 module.exports = {

--- a/app/confirmation/post.controller.js
+++ b/app/confirmation/post.controller.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const {renderErrorView} = require('../../common/response')
+const connectorClient = require('../../common/clients/connector-client')
+module.exports = (req, res) => {
+  const paymentRequest = req.session.paymentRequest
+  connectorClient.payment.confirmDirectDebitDetails(paymentRequest.gatewayAccountId, req.params.paymentRequestExternalId)
+    .then(() => {
+      return res.redirect(303, req.session.paymentRequest.returnUrl)
+    })
+    .catch(() => {
+      renderErrorView(req, res, 'No money has been taken from your account, please try again later.', 500)
+    })
+}

--- a/app/secure/post.controller.js
+++ b/app/secure/post.controller.js
@@ -9,6 +9,8 @@ module.exports = (req, res) => {
     .then(paymentRequest => {
       // todo need to generate csrf
       // todo need to delete token
+      // fixme probably not ideal to stick the charge in the session, but will do for now
+      req.session.paymentRequest = paymentRequest
       let url = setup.paths.index.replace(':paymentRequestExternalId', paymentRequest.externalId)
       return res.redirect(303, url)
     })

--- a/app/setup/get.controller.js
+++ b/app/setup/get.controller.js
@@ -4,8 +4,12 @@
 const countries = require('../../common/utils/countries')
 
 module.exports = (req, res) => {
+  const paymentRequest = req.session.paymentRequest
   const params = {
-    countries: countries.retrieveCountries()
+    countries: countries.retrieveCountries(),
+    paymentRequestExternalId: req.params.paymentRequestExternalId,
+    description: paymentRequest.description,
+    amount: paymentRequest.amount
   }
   res.render('app/setup/get', params)
 }

--- a/app/setup/get.njk
+++ b/app/setup/get.njk
@@ -7,17 +7,14 @@
 
 {% block content %}
   <main id="content" role="main">
-    <div>
-      <a href="/setup" class="link-back">Back</a>
-    </div>
     <div class="grid-row relative">
       <div class="column-two-thirds">
         <h1 class="heading-large">Set up a Direct Debit</h1>
         <p>We’ll take a one-off payment from your bank account</p>
 
-        <form class="form" method="POST" action="/setup" class="direct-debit-form" data-validate>
+        <form class="form" method="POST" action="/setup/{{paymentRequestExternalId}}" class="direct-debit-form" data-validate>
           {{ form.input(
-            name='name',
+            name='account-holder-name',
             label='Name on the account',
             extraClasses='form-control-2-3',
             validate='true',
@@ -48,11 +45,11 @@
                 </h1>
               </legend>
               <div class="multiple-choice">
-                <input id="authorise-yes" type="radio" name="authorise" value="yes" />
+                <input id="authorise-yes" type="radio" name="requires-authorisation" value="false" />
                 <label for="authorise-yes">Yes</label>
               </div>
               <div class="multiple-choice" data-target="unauthorised-message">
-                <input id="authorise-no" type="radio" name="authorise" value="no" aria-controls="unauthorised-message" aria-expanded="false"/>
+                <input id="authorise-no" type="radio" name="requires-authorisation" value="true" aria-controls="unauthorised-message" aria-expanded="false"/>
                 <label for="example-contact-by-phone">No</label>
               </div>
               <div class="panel panel-border-narrow js-hidden" id="unauthorised-message" aria-hidden="true">
@@ -64,7 +61,7 @@
           </div>
 
           {{ form.selectCountries(
-            name='country',
+            name='country-code',
             label='Countries',
             extraClasses='form-control-2-3',
             before='<h2 class="heading-medium">Billing address</h2><p>This is the address associated with the account</p>',
@@ -79,7 +76,7 @@
           </div>
 
           {{ form.input(
-            name='address-city',
+            name='city',
             label='Town or city',
             extraClasses='form-control-2-3',
             validate='true',
@@ -87,7 +84,7 @@
           )}}
 
           {{ form.input(
-            name='address-postcode',
+            name='postcode',
             label='Postcode',
             extraClasses='form-control-1-3',
             validate='true',
@@ -111,8 +108,8 @@
       <aside class="payment-summary">
         <div class="payment-summary__inner js-stick-at-top-when-scrolling">
           <h2 class="heading-medium">Payment summary</h2>
-          <p class="payment-summary__description">Lock and Weir Fishing Permit – River Thames</p>
-          <p class="payment-summary__description">Total amount: <span class="payment-summary__amount">£31.00</span>
+          <p class="payment-summary__description" id="payment-description">{{description}}</p>
+          <p class="payment-summary__description">Total amount: <span class="payment-summary__amount" id="amount">£{{amount}}</span>
         </div>
       </aside>
     </div>

--- a/app/setup/post.controller.js
+++ b/app/setup/post.controller.js
@@ -1,8 +1,38 @@
 'use strict'
 
+// NPM dependencies
+const _ = require('lodash')
+
 // Local dependencies
 const confirmation = require('./../confirmation')
+const Payer = require('../../common/classes/Payer.class')
+const {renderErrorView} = require('../../common/response')
+const connectorClient = require('../../common/clients/connector-client')
 
 module.exports = (req, res) => {
-  res.redirect(confirmation.paths.index)
+  let paymentRequest = req.session.paymentRequest
+  const requestBody = req.body
+  let formValues = { account_holder_name: _.get(requestBody, 'account-holder-name'),
+    sort_code: _.get(requestBody, 'sort-code'),
+    account_number: _.get(requestBody, 'account-number'),
+    requires_authorisation: _.get(requestBody, 'requires-authorisation'),
+    country_code: _.get(requestBody, 'country-code'),
+    address_line1: _.get(requestBody, 'address-line1'),
+    city: _.get(requestBody, 'city'),
+    postcode: _.get(requestBody, 'postcode'),
+    email: _.get(requestBody, 'email') }
+  if (_.get(requestBody, 'address-line2')) {
+    formValues.address_line2 = _.get(requestBody, 'address-line2')
+  }
+  connectorClient.payment.submitDirectDebitDetails(paymentRequest.gatewayAccountId, req.params.paymentRequestExternalId, formValues)
+    .then(payerExternalId => {
+      req.body.payer_external_id = payerExternalId
+      req.session.confirmationDetails = new Payer(formValues)
+      let url = confirmation.paths.index.replace(':paymentRequestExternalId', req.params.paymentRequestExternalId)
+      return res.redirect(303, url)
+    })
+    .catch(() => {
+      // todo re-render this page with meaningful validation errors if connector gives back a 400 Bad Request
+      renderErrorView(req, res, 'No money has been taken from your account, please try again later.', 500)
+    })
 }

--- a/app/setup/post.controller.tests.js
+++ b/app/setup/post.controller.tests.js
@@ -1,17 +1,73 @@
 'use strict'
 
 // npm dependencies
+const chai = require('chai')
+const expect = chai.expect
 const supertest = require('supertest')
+const nock = require('nock')
 
 // Local dependencies
+const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+const config = require('../../common/config')
 const getApp = require('../../server').getApp
+const confirmation = require('../confirmation')
+const {CookieBuilder} = require('../../test/test_helpers/cookie-helper')
 
-describe('POST /setup page', function () {
-  it('should return HTTP 302 status and redirect', function (done) {
-    supertest(getApp())
-      .post('/setup/somepaymentrequest')
-      .expect(302)
-      .expect('Location', '/confirmation')
-      .end(done)
+describe('setup post controller', () => {
+  let response
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+  describe('when submitting the form for a valid payment request', () => {
+    let paymentRequestExternalId = 'sdfihsdufh2e'
+    let paymentRequest = paymentFixtures.validPaymentRequest({
+      external_id: paymentRequestExternalId
+    })
+    let formValues = paymentFixtures.validPayer()
+    before(done => {
+      const cookieHeader = new CookieBuilder()
+        .withPaymentRequest(paymentRequest)
+        .build()
+      let createPayerResponse = paymentFixtures.validCreatePayerResponse().getPlain()
+      nock(config.CONNECTOR_URL)
+        .post(`/v1/api/accounts/${paymentRequest.gatewayAccountId}/payment-requests/${paymentRequestExternalId}/payers`, { account_holder_name: formValues.accountHolderName,
+          sort_code: formValues.sortCode,
+          account_number: formValues.accountNumber,
+          requires_authorisation: formValues.requiresAuthorisation,
+          country_code: formValues.country,
+          address_line1: formValues.addressLine1,
+          address_line2: formValues.addressLine2,
+          city: formValues.city,
+          postcode: formValues.postcode,
+          email: formValues.email })
+        .reply(201, createPayerResponse)
+      supertest(getApp())
+        .post(`/setup/${paymentRequestExternalId}`)
+        .send({ 'account-holder-name': formValues.accountHolderName,
+          'sort-code': formValues.sortCode,
+          'account-number': formValues.accountNumber,
+          'requires-authorisation': formValues.requiresAuthorisation,
+          'country-code': formValues.country,
+          'address-line1': formValues.addressLine1,
+          'address-line2': formValues.addressLine2,
+          'city': formValues.city,
+          'postcode': formValues.postcode,
+          'email': formValues.email })
+        .set('Cookie', cookieHeader)
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json')
+        .end((err, res) => {
+          response = res
+          done(err)
+        })
+    })
+    it('should redirect to /confirm', () => {
+      expect(response.statusCode).to.equal(303)
+    })
+    it('should redirect to the insert direct debit details page', () => {
+      let url = confirmation.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
+      expect(response.header).property('location').to.equal(url)
+    })
   })
 })

--- a/common/classes/Payer.class.js
+++ b/common/classes/Payer.class.js
@@ -1,0 +1,19 @@
+'use strict'
+
+class Payer {
+  constructor (opts) {
+    this.externalId = opts.payer_external_id
+    this.accountHolderName = opts.account_holder_name
+    this.email = opts.email
+    this.accountNumber = opts.account_number
+    this.sortCode = opts.sort_code
+    this.requiresAuthorisation = opts.requires_authorisation
+    this.country = opts.country_code
+    this.addressLine1 = opts.address_line1
+    this.addressLine2 = opts.address_line2
+    this.city = opts.city
+    this.postcode = opts.postcode
+  }
+}
+
+module.exports = Payer

--- a/common/classes/PaymentRequest.class.js
+++ b/common/classes/PaymentRequest.class.js
@@ -3,10 +3,15 @@
 class PaymentRequest {
   constructor (opts) {
     this.externalId = opts.external_id
-    this.amount = opts.amount
+    this.returnUrl = opts.return_url
+    this.gatewayAccountId = opts.gateway_account_id
+    this.amount = penceToPounds(opts.amount)
+    this.description = opts.description
     this.type = opts.type
     this.state = opts.state
   }
 }
-
+let penceToPounds = (pence) => {
+  return (parseInt(pence) / 100).toFixed(2)
+}
 module.exports = PaymentRequest

--- a/common/clients/connector-client.js
+++ b/common/clients/connector-client.js
@@ -9,12 +9,15 @@ const service = 'connector'
 const baseUrl = `${CONNECTOR_URL}/v1`
 const headers = {
 }
-
 // Exports
 module.exports = {
   secure: {
     retrievePaymentRequest: retrievePaymentRequest,
     deleteToken: deleteToken
+  },
+  payment: {
+    submitDirectDebitDetails: submitDirectDebitDetails,
+    confirmDirectDebitDetails: confirmDirectDebitDetails
   }
 }
 
@@ -22,7 +25,7 @@ function retrievePaymentRequest (token) {
   return baseClient.get({
     headers,
     baseUrl,
-    url: `/tokens/${token}/charge`,
+    url: `/tokens/${token}/payment-request`,
     service: service,
     description: `retrieve a payment request by its one-time token`
   }).then(paymentRequest => new PaymentRequest(paymentRequest))
@@ -35,5 +38,29 @@ function deleteToken (token) {
     url: `/tokens/${token}`,
     service: service,
     description: `delete a one-time token`
+  })
+}
+
+function submitDirectDebitDetails (accountId, paymentRequestExternalId, body) {
+  return baseClient.post({
+    headers,
+    baseUrl,
+    json: true,
+    url: `/api/accounts/${accountId}/payment-requests/${paymentRequestExternalId}/payers`,
+    service: service,
+    body: body,
+    description: `create a payer and store hashed bank account details`
+  }).then(response => {
+    return response.payer_external_id
+  })
+}
+function confirmDirectDebitDetails (accountId, paymentRequestExternalId) {
+  return baseClient.post({
+    headers,
+    baseUrl,
+    json: true,
+    url: `/api/accounts/${accountId}/payment-requests/${paymentRequestExternalId}/confirm`,
+    service: service,
+    description: `confirm a payment`
   })
 }

--- a/common/config/cookies.js
+++ b/common/config/cookies.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const SESSION_ENCRYPTION_KEY = process.env.SESSION_ENCRYPTION_KEY
+const COOKIE_MAX_AGE_SESSION = process.env.COOKIE_MAX_AGE
+
+if (!SESSION_ENCRYPTION_KEY) {
+  throw new Error('cookie encryption key is not set')
+}
+
+if (!COOKIE_MAX_AGE_SESSION) {
+  throw new Error('cookie max age is not set')
+}
+
+exports.session = {
+  cookieName: 'session', // cookie name dictates the key name added to the request object
+  secret: SESSION_ENCRYPTION_KEY,
+  duration: parseInt(COOKIE_MAX_AGE_SESSION), // how long the session will stay valid in ms
+  proxy: true,
+  cookie: {
+    ephemeral: false, // when true, cookie expires when the browser closes
+    httpOnly: true, // when true, cookie is not accessible from javascript
+    secureProxy: true
+  }
+}

--- a/common/utils/middleware.js
+++ b/common/utils/middleware.js
@@ -1,0 +1,9 @@
+module.exports.excludingPaths = function (paths, middleware) {
+  return function (req, res, next) {
+    if (paths.indexOf(req.url) >= 0) {
+      next()
+    } else {
+      return middleware(req, res, next)
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "body-parser": "1.18.x",
+    "client-sessions": "0.8.x",
     "compression": "1.7.x",
     "correlation-id": "^2.0.0",
     "express": "4.16.x",

--- a/server.js
+++ b/server.js
@@ -12,11 +12,14 @@ const argv = require('minimist')(process.argv.slice(2))
 const staticify = require('staticify')(path.join(__dirname, 'public'))
 const compression = require('compression')
 const nunjucks = require('nunjucks')
+const clientSession = require('client-sessions')
 
 // Local dependencies
 const router = require('./app/router')
 const noCache = require('./common/utils/no-cache')
 const correlationHeader = require('./common/middleware/correlation-header')
+const middlwareUtils = require('./common/utils/middleware')
+const cookieConfig = require('./common/config/cookies')
 
 // Global constants
 const unconfiguredApp = express()
@@ -53,6 +56,9 @@ function initialiseGlobalMiddleware (app) {
   app.use(bodyParser.urlencoded({ extended: true }))
 
   app.use('*', correlationHeader)
+}
+function initialiseCookies (app) {
+  app.use(middlwareUtils.excludingPaths(['/healthcheck'], clientSession(cookieConfig.session)))
 }
 
 function initialiseI18n (app) {
@@ -122,6 +128,7 @@ function initialise () {
   const app = unconfiguredApp
   app.disable('x-powered-by')
   initialiseProxy(app)
+  initialiseCookies(app)
   initialiseI18n(app)
   initialiseGlobalMiddleware(app)
   initialiseTemplateEngine(app)

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -1,21 +1,64 @@
 'use strict'
+const Payer = require('../../common/classes/Payer.class')
+const PaymentRequest = require('../../common/classes/PaymentRequest.class')
 // Create random values if none provided
 const randomExternalId = () => Math.random().toString(36).substring(7)
 const randomAmount = () => Math.round(Math.random() * 10000) + 1
-
+const randomUrl = () => 'https://' + randomExternalId() + '.com'
 // todo add pactified
 module.exports = {
   validTokenExchangeResponse: (opts = {}) => {
     const data = {
       external_id: opts.external_id || randomExternalId(),
-      amount: opts.amount || 'pay-api-token',
-      name: opts.type || 'CHARGE',
-      price: opts.state || randomAmount()
+      amount: opts.amount || randomAmount(),
+      description: opts.description || 'buy Silvia a coffee',
+      type: opts.type || 'CHARGE',
+      state: opts.state || randomAmount(),
+      return_url: opts.return_url || randomUrl(),
+      gateway_account_id: opts.gatewayAccountId || randomAmount()
     }
     return {
       getPlain: () => {
         return data
       }
     }
+  },
+  validCreatePayerResponse: (opts = {}) => {
+    const data = {
+      payer_external_id: opts.payer_external_id || randomExternalId()
+    }
+    return {
+      getPlain: () => {
+        return data
+      }
+    }
+  },
+  validPayer: (opts = {}) => {
+    const data = {
+      payer_external_id: opts.payer_external_id || randomExternalId(),
+      account_holder_name: opts.account_holder_name || 'mr. payment',
+      email: opts.email || 'aa@bb.com',
+      account_number: opts.account_number || '12345678',
+      sort_code: opts.sort_code || '123456',
+      requires_authorisation: opts.requires_authorisation || 'false',
+      country_code: opts.country_code || 'GB',
+      address_line1: opts.address_line1 || 'line1',
+      address_line2: opts.address_line2 || 'line2',
+      postcode: opts.postcode || 'postcode',
+      city: opts.city || 'city'
+    }
+    return new Payer(data)
+  },
+  validPaymentRequest: (opts = {}) => {
+    const data = {
+      external_id: opts.external_id || randomExternalId(),
+      return_url: randomUrl() || opts.return_url,
+      gateway_account_id: 23 || opts.gateway_account_id,
+      description: opts.description || 'buy Silvia a coffee',
+      amount: opts.amount || randomAmount(),
+      type: 'CHARGE' || opts.type,
+      state: 'NEW' || opts.state
+    }
+    return new PaymentRequest(data)
   }
 }

--- a/test/test.env
+++ b/test/test.env
@@ -1,0 +1,4 @@
+CONNECTOR_URL=http://localhost:8004
+NODE_ENV=test
+COOKIE_MAX_AGE=5400000
+SESSION_ENCRYPTION_KEY=asdjhbwefbo23r23rbfik2roiwhefwbqw

--- a/test/test_helpers/cookie-helper.js
+++ b/test/test_helpers/cookie-helper.js
@@ -1,0 +1,66 @@
+'use strict'
+
+// npm dependencies
+const clientSession = require('client-sessions')
+const _ = require('lodash')
+
+// local dependencies
+const cookieConfig = require('../../common/config/cookies')
+
+let configs = []
+
+for (const property in cookieConfig) {
+  configs.push(cookieConfig[property])
+}
+
+exports.CookieBuilder = class CookieBuilder {
+  constructor () {
+    this._cookies = {}
+  }
+  withPaymentRequest (paymentRequestfixture) {
+    this.withCookie('session', {
+      paymentRequest: paymentRequestfixture,
+    })
+    return this
+  }
+  withConfirmationDetails (payerFixture) {
+    this.withCookie('session', {
+      confirmationDetails: payerFixture,
+    })
+    return this
+  }
+  withCookie (cookieName, value) {
+    this._cookies[cookieName] = Object.assign(this._cookies[cookieName] || {}, value)
+    return this
+  }
+  build () {
+    let cookiesArray = []
+    Object.keys(this._cookies).forEach(cookieName => {
+      const config = configs.find(config => config.cookieName === cookieName)
+      const value = config ? clientSession.util.encode(config, this._cookies[cookieName]) : this._cookies[cookieName]
+      cookiesArray.push(`${cookieName}=${value}`)
+    })
+    return cookiesArray.join('; ')
+  }
+}
+
+exports.decryptCookie = (rawCookieHeader) => {
+  const cookies = {}
+
+  rawCookieHeader.forEach(rawCookie => {
+    const formatted = {}
+    const tuples = rawCookie
+      .split(';')
+      .map(cookie => cookie.split('=').map(item => item.trim()))
+    const cookieName = tuples[0][0]
+    const config = configs.find(config => config.cookieName === cookieName)
+    tuples[0][0] = 'content'
+    tuples.forEach(tuple => {
+      formatted[tuple[0]] = tuple[1] || true
+    })
+    if (config) Object.assign(formatted, clientSession.util.decode(config, formatted.content))
+    cookies[cookieName] = formatted
+  })
+
+  return cookies
+}

--- a/test/test_helpers/cookie-helper.js
+++ b/test/test_helpers/cookie-helper.js
@@ -2,7 +2,6 @@
 
 // npm dependencies
 const clientSession = require('client-sessions')
-const _ = require('lodash')
 
 // local dependencies
 const cookieConfig = require('../../common/config/cookies')
@@ -19,13 +18,13 @@ exports.CookieBuilder = class CookieBuilder {
   }
   withPaymentRequest (paymentRequestfixture) {
     this.withCookie('session', {
-      paymentRequest: paymentRequestfixture,
+      paymentRequest: paymentRequestfixture
     })
     return this
   }
   withConfirmationDetails (payerFixture) {
     this.withCookie('session', {
-      confirmationDetails: payerFixture,
+      confirmationDetails: payerFixture
     })
     return this
   }


### PR DESCRIPTION
## WHAT
 - Adding a few calls to the dd connector client, this should be merged after alphagov/pay-direct-debit-connector#39  because it builds on the changes in the token response made in that PR
 - Adding support of cheerio in tests and restructuring them to use the awesome patterns by @maxcbc
 - Adding fixtures for generating test data
 - Sticking `ALL THE THINGS` in the cookie session right now - this is probably not what we want in the future but it's ok to get our e2e flow and unblocking lots of things in our pipeline
 - Tests are by no mean exhaustive, they are covering the very basics and are more like a foundation on which we should keep building after we have a more defined structure
 
## HOW TO TEST
- Until connector is merged, test locally by checking out https://github.com/alphagov/pay-direct-debit-connector/tree/PP-3106_add_logging_of_exception and doing `msl up`
- Do a `msl up` of the new frontend
- Create a token in pay-scripts with `./accounts.sh -t DIRECT_DEBIT`
- Run a payment journey 
- ???
-  #Profit 