### PR TITLE
PP-2967 Rollback of "build and test" libraries

### DIFF
--- a/docker/build_and_test.Dockerfile
+++ b/docker/build_and_test.Dockerfile
@@ -2,7 +2,7 @@ FROM govukpay/nodejs:6.12.2
 
 RUN apk update &&\
     apk upgrade &&\
-    apk add --update bash ruby
+    apk add --update bash python make g++ ruby openssl
 
 ADD docker/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 


### PR DESCRIPTION
## WHAT

Rollback of `build_and_test.Dockerfile` installed libraries.
Should fix:
```
Can't find Python executable "python"
```
also rolled back other libraries (originally presented)

Related PR: https://github.com/alphagov/pay-direct-debit-frontend/pull/26