### PR TITLE
PP-2939 Run e2e when merging to master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,11 @@ pipeline {
         }
       }
     }
+    stage('Test') {
+      steps {
+        runParameterisedEndToEnd("directdebitfrontend", null, "end2end-tagged", false, false, "uk.gov.pay.endtoend.categories.End2EndDirectDebit")
+      }
+    }
     stage('Docker Tag') {
       steps {
         script {

--- a/server.js
+++ b/server.js
@@ -88,7 +88,7 @@ function initialiseTemplateEngine (app) {
     throwOnUndefined: false, // throw errors when outputting a null/undefined value
     trimBlocks: true, // automatically remove trailing newlines from a block/tag
     lstripBlocks: true, // automatically remove leading whitespace from a block/tag
-    watch: false, // reload templates when they are changed (server-side). To use watch, make sure optional dependency chokidar is installed
+    watch: NODE_ENV !== 'production', // reload templates when they are changed (server-side). To use watch, make sure optional dependency chokidar is installed
     noCache: NODE_ENV !== 'production' // never use a cache and recompile templates each time (server-side)
   }
 


### PR DESCRIPTION
## WHAT
- Adding a step in the jenkins pipeline to direct debit run end to end tests
- Re-enabling the nunjucks watcher, knowing that it will be disabled in jenkins (because `NODE_ENV` is set to production)