### PR TITLE
PP-2939 Disable nunjucks' watcher again

### DIFF
--- a/server.js
+++ b/server.js
@@ -88,7 +88,7 @@ function initialiseTemplateEngine (app) {
     throwOnUndefined: false, // throw errors when outputting a null/undefined value
     trimBlocks: true, // automatically remove trailing newlines from a block/tag
     lstripBlocks: true, // automatically remove leading whitespace from a block/tag
-    watch: NODE_ENV !== 'production', // reload templates when they are changed (server-side). To use watch, make sure optional dependency chokidar is installed
+    watch: false, // reload templates when they are changed (server-side). To use watch, make sure optional dependency chokidar is installed
     noCache: NODE_ENV !== 'production' // never use a cache and recompile templates each time (server-side)
   }
 


### PR DESCRIPTION
## WHAT
The frontend containers on ECS have correctly NODE_ENV set to production - jenkins builds it with NODE_ENV=test, so disabling the watcher will fix the ENOSPC issue.

@jonheslop would be good to understand why enabling the watcher makes the docker container watch too many files :(