### PR TITLE
Revert "PP-2939 Temporarily disable e2e on merge"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,11 @@ pipeline {
         }
       }
     }
+    stage('Test') {
+      steps {
+        runParameterisedEndToEnd("directdebitfrontend", null, "end2end-tagged", false, false, "uk.gov.pay.endtoend.categories.End2EndDirectDebit")
+      }
+    }
     stage('Docker Tag') {
       steps {
         script {


### PR DESCRIPTION
Reverts alphagov/pay-direct-debit-frontend#33

We can re-enable end to end on merges as now it actually runs 🚀 