### PR TITLE
BAU: Fix certificate parsing

### DIFF
--- a/common/utils/certificates/custom-certificate.js
+++ b/common/utils/certificates/custom-certificate.js
@@ -24,9 +24,13 @@ exports.addCertsToAgent = agentOptions => {
   }
 
   agentOptions.ca = agentOptions.ca || []
-  fs.readdirSync(certsPath).forEach(
-    (certPath) => agentOptions.ca.push(
-      fs.readFileSync(path.join(certsPath, certPath))
-    )
-  )
+  // Read everything from the certificates directories
+  // Get everything that isn't a directory (e.g. files, symlinks)
+  // Read it (assume it is a certificate)
+  // Add it to the agentOptions list of CAs
+  fs.readdirSync(certsPath)
+    .map(certPath => path.join(certsPath, certPath))
+    .filter(fullCertPath => !fs.lstatSync(fullCertPath).isDirectory())
+    .map(fullCertPath => fs.readFileSync(fullCertPath))
+    .forEach(ca => agentOptions.ca.push(ca))
 }


### PR DESCRIPTION
We attempted to grab everything in the CERTS_PATH and use it as a CA, including directories...

When we added `/etc/ssl/certs/java/cacerts` we attempted to use `/etc/ssl/certs/java` as a CA...