### PR TITLE
PP-3080 Relaxed sort code validation

### DIFF
--- a/app/setup/get.njk
+++ b/app/setup/get.njk
@@ -37,7 +37,7 @@
             value=formValues.sort_code,
             extraClasses='form-control-1-3',
             attributes={'data-validate': 'sort-code'},
-            errorLabel='Sort codes must contain 6 digits',
+            errorLabel='Sort code must contain 6 digits',
             isError=errors['sort-code']
           )}}
 
@@ -47,7 +47,7 @@
             value=formValues.account_number,
             extraClasses='form-control-1-3',
             attributes={'data-validate': 'account-number'},
-            errorLabel='Account numbers must contain 6-8 digits',
+            errorLabel='Account number must contain 6-8 digits',
             isError=errors['account-number']
           )}}
 

--- a/common/browsered/field-validation-checks.js
+++ b/common/browsered/field-validation-checks.js
@@ -5,31 +5,16 @@ const emailValidator = require('../utils/email-validator')
 // Constants
 const NUMBERS_ONLY = new RegExp('^[0-9]+$')
 
-const isEmpty = value => {
-  return value.trim() === ''
-}
+// Exports
+exports.isEmpty = value => value.trim() === ''
 
-const isChecked = field => {
-  return field && (field.checked === true)
-}
+exports.isChecked = field => field && (field.checked === true)
 
-const isValidEmail = function (value) {
-  return emailValidator(value)
-}
+exports.isValidEmail = value => emailValidator(value)
 
-const isSortCode = value => {
-  return /^\s?(\d{2}\s?-?\s?){2}\d{2}\s?$/.test(value)
-}
+exports.isSortCode = value => /^[ -]*(?:[0-9][ -]*){6}$/.test(value)
 
-const isAccountNumber = value => {
+exports.isAccountNumber = value => {
   const trimmedAccountNumber = value.replace(/\s/g, '')
   return NUMBERS_ONLY.test(trimmedAccountNumber) && (trimmedAccountNumber.length >= 6 && trimmedAccountNumber.length <= 8)
-}
-
-module.exports = {
-  isEmpty,
-  isChecked,
-  isSortCode,
-  isAccountNumber,
-  isValidEmail
 }

--- a/common/browsered/field-validation-checks.test.js
+++ b/common/browsered/field-validation-checks.test.js
@@ -8,10 +8,21 @@ const {isSortCode, isAccountNumber, isChecked} = require('./field-validation-che
 
 describe('field validation checks', () => {
   describe('isSortCode', () => {
-    it('should return an error message if its a invalid sort code', () => {
+    it('should return false if it is a invalid sort code', () => {
+      expect(isSortCode('12345')).to.equal(false)
+      expect(isSortCode('1234567')).to.equal(false)
+      expect(isSortCode('0234567')).to.equal(false)
+      expect(isSortCode('-12345')).to.equal(false)
+      expect(isSortCode('12345-')).to.equal(false)
       expect(isSortCode('12-3-45')).to.equal(false)
       expect(isSortCode('12-34-567')).to.equal(false)
       expect(isSortCode('12-3a-56')).to.equal(false)
+      expect(isSortCode(' 12345')).to.equal(false)
+      expect(isSortCode('12345 ')).to.equal(false)
+      expect(isSortCode('12 3 45')).to.equal(false)
+      expect(isSortCode('12 34 567')).to.equal(false)
+      expect(isSortCode('12 3a 56')).to.equal(false)
+      expect(isSortCode('123$@456')).to.equal(false)
     })
 
     it('should return true if it is a valid sort code', () => {
@@ -19,6 +30,10 @@ describe('field validation checks', () => {
       expect(isSortCode('12 34 56')).to.equal(true)
       expect(isSortCode('123456')).to.equal(true)
       expect(isSortCode('01-23-45')).to.equal(true)
+      expect(isSortCode('01 23 45')).to.equal(true)
+      expect(isSortCode('----0-1-2-3-4-5----')).to.equal(true)
+      expect(isSortCode('    0  1 2   3 4 5   ')).to.equal(true)
+      expect(isSortCode('-123456-')).to.equal(true)
       expect(isSortCode(' 123456 ')).to.equal(true)
     })
   })
@@ -26,7 +41,7 @@ describe('field validation checks', () => {
 
 describe('field validation checks', () => {
   describe('isAccountNumber', () => {
-    it('should return an error message if its a invalid account number', () => {
+    it('should return false if it is a invalid account number', () => {
       expect(isAccountNumber('123-456')).to.equal(false)
       expect(isAccountNumber('1-2-3-4-5-6')).to.equal(false)
       expect(isAccountNumber('12-34-56')).to.equal(false)
@@ -48,7 +63,7 @@ describe('field validation checks', () => {
 
 describe('field validation checks', () => {
   describe('isChecked', () => {
-    it('should return an error message if the field is not checked', () => {
+    it('should return false if the field is not checked', () => {
       expect(isChecked({checked: false})).to.equal(false)
     })
 


### PR DESCRIPTION
## WHAT

- Relaxed sort code validation: now it accepts any combination of whitespace, dashes and digits, exactly six digits
- Removed usage of `module.exports` as described in https://github.com/alphagov/pay-frontend/commit/0b2a1516f9ab91c013b9dc466bc8e1a14c433254
- Error message improvements

with @alexbishop1