### PR TITLE
PP-3080 Better sort code formatting

### DIFF
--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -7,7 +7,7 @@ module.exports = (req, res) => {
     paymentRequestExternalId: req.params.paymentRequestExternalId,
     accountHolderName: confirmationDetails.accountHolderName,
     accountNumber: confirmationDetails.accountNumber,
-    sortCode: confirmationDetails.sortCode,
+    sortCode: confirmationDetails.sortCode.match(/.{2}/g).join(' '),
     returnUrl: paymentRequest.returnUrl,
     description: paymentRequest.description,
     amount: paymentRequest.amount

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -17,6 +17,7 @@ describe('confirmation get controller', function () {
   const paymentRequestExternalId = 'sdfihsdufh2e'
   const accountName = 'bla'
   const sortCode = '123456'
+  const formattedSortCode = '12 34 56'
   const accountNumber = '12345678'
   const description = 'this is a description'
   const amount = 1000
@@ -58,7 +59,7 @@ describe('confirmation get controller', function () {
 
   it('should display the confirmation page with the payer details', () => {
     expect($('#account-holder-name').text()).to.equal(accountName)
-    expect($('#sort-code').text()).to.equal(sortCode)
+    expect($('#sort-code').text()).to.equal(formattedSortCode)
     expect($('#account-number').text()).to.equal(accountNumber)
   })
 


### PR DESCRIPTION
## WHAT

This PR adds better sort code formatting.

As per GOV.UK styling guide for sort code we should use spaces in sort codes - 60 70 80 (not 60-70-80 and not 607080)

More information: https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#bank-details
