### PR TITLE
PP-3044 Handle multiple payments in session, and set request id in logs

### DIFF
--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -1,10 +1,13 @@
 'use strict'
+const {getSessionVariable} = require('../../common/config/cookies')
 
 module.exports = (req, res) => {
-  const confirmationDetails = req.session.confirmationDetails
-  const paymentRequest = req.session.paymentRequest
+  const paymentRequestExternalId = req.params.paymentRequestExternalId
+  const session = getSessionVariable(req, paymentRequestExternalId)
+  const paymentRequest = session.paymentRequest
+  const confirmationDetails = session.confirmationDetails
   const params = {
-    paymentRequestExternalId: req.params.paymentRequestExternalId,
+    paymentRequestExternalId,
     accountHolderName: confirmationDetails.accountHolderName,
     accountNumber: confirmationDetails.accountNumber,
     sortCode: confirmationDetails.sortCode.match(/.{2}/g).join(' '),

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -33,8 +33,7 @@ describe('confirmation get controller', function () {
       sort_code: sortCode,
       account_number: accountNumber
     })
-    const cookieHeader = new CookieBuilder()
-      .withPaymentRequest(paymentRequest)
+    const cookieHeader = new CookieBuilder(paymentRequest)
       .withCsrfSecret('123')
       .withConfirmationDetails(payer)
       .build()

--- a/app/confirmation/index.js
+++ b/app/confirmation/index.js
@@ -7,6 +7,7 @@ const express = require('express')
 const getController = require('./get.controller')
 const postController = require('./post.controller')
 const {validateAndRefreshCsrf} = require('../../common/middleware/csrf')
+const {ensureSessionHasPaymentRequest} = require('../../common/middleware/get-payment-request')
 
 // Initialisation
 const router = express.Router()
@@ -16,8 +17,8 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, validateAndRefreshCsrf, getController)
-router.post(paths.index, validateAndRefreshCsrf, postController)
+router.get(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getController)
+router.post(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, postController)
 
 // Export
 module.exports = {

--- a/app/confirmation/post.controller.js
+++ b/app/confirmation/post.controller.js
@@ -2,11 +2,14 @@
 
 const {renderErrorView} = require('../../common/response')
 const connectorClient = require('../../common/clients/connector-client')
+const {getSessionVariable} = require('../../common/config/cookies')
+
 module.exports = (req, res) => {
-  const paymentRequest = req.session.paymentRequest
-  connectorClient.payment.confirmDirectDebitDetails(paymentRequest.gatewayAccountId, req.params.paymentRequestExternalId)
+  const paymentRequestExternalId = req.params.paymentRequestExternalId
+  const paymentRequest = getSessionVariable(req, paymentRequestExternalId).paymentRequest
+  connectorClient.payment.confirmDirectDebitDetails(paymentRequest.gatewayAccountId, paymentRequestExternalId, req.correlationId)
     .then(() => {
-      return res.redirect(303, req.session.paymentRequest.returnUrl)
+      return res.redirect(303, paymentRequest.returnUrl)
     })
     .catch(() => {
       renderErrorView(req, res, 'No money has been taken from your account, please try again later.', 500)

--- a/app/confirmation/post.controller.tests.js
+++ b/app/confirmation/post.controller.tests.js
@@ -22,8 +22,7 @@ const paymentRequest = paymentFixtures.validPaymentRequest({
 describe('confirmation POST controller', () => {
   const csrfSecret = '123'
   const csrfToken = csrf().create(csrfSecret)
-  const cookieHeader = new CookieBuilder()
-    .withPaymentRequest(paymentRequest)
+  const cookieHeader = new CookieBuilder(paymentRequest)
     .withCsrfSecret(csrfSecret)
     .build()
   afterEach(() => {

--- a/app/secure/get.post.controller.js
+++ b/app/secure/get.post.controller.js
@@ -3,15 +3,17 @@
 const {renderErrorView} = require('../../common/response')
 const connectorClient = require('../../common/clients/connector-client')
 const setup = require('../setup')
+const {setSessionVariable} = require('../../common/config/cookies')
 module.exports = (req, res) => {
   const token = req.body.chargeTokenId || req.params.chargeTokenId
-  connectorClient.secure.retrievePaymentRequest(token)
+  connectorClient.secure.retrievePaymentRequest(token, req.correlationId)
+    .then(paymentRequest => connectorClient.secure.deleteToken(token, req.correlationId).then(() => Promise.resolve(paymentRequest)))
     .then(paymentRequest => {
-      // todo need to generate csrf
-      // todo need to delete token
-      // fixme probably not ideal to stick the charge in the session, but will do for now
-      req.session.paymentRequest = paymentRequest
-      let url = setup.paths.index.replace(':paymentRequestExternalId', paymentRequest.externalId)
+      const paymentRequestExternalId = paymentRequest.externalId
+      setSessionVariable(req, paymentRequestExternalId, {
+        paymentRequest
+      })
+      const url = setup.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
       return res.redirect(303, url)
     })
     .catch(() => {

--- a/app/secure/get.post.controller.tests.js
+++ b/app/secure/get.post.controller.tests.js
@@ -24,6 +24,7 @@ describe('secure controller', () => {
     before(done => {
       paymentRequest = paymentFixtures.validTokenExchangeResponse().getPlain()
       nock(config.CONNECTOR_URL).get(`/v1/tokens/${token}/payment-request`).reply(200, paymentRequest)
+      nock(config.CONNECTOR_URL).delete(`/v1/tokens/${token}`).reply(200)
       supertest(getApp())
         .get(`/secure/${token}`)
         .set('Content-Type', 'application/json')
@@ -48,6 +49,7 @@ describe('secure controller', () => {
     before(done => {
       const token = 'invalid'
       nock(config.CONNECTOR_URL).get(`/v1/tokens/${token}/payment-request`).reply(404)
+      nock(config.CONNECTOR_URL).delete(`/v1/tokens/${token}`).reply(200)
       supertest(getApp())
         .get(`/secure/${token}`)
         .set('Content-Type', 'application/json')
@@ -74,6 +76,7 @@ describe('secure controller', () => {
       before(done => {
         paymentRequest = paymentFixtures.validTokenExchangeResponse().getPlain()
         nock(config.CONNECTOR_URL).get(`/v1/tokens/${token}/payment-request`).reply(200, paymentRequest)
+        nock(config.CONNECTOR_URL).delete(`/v1/tokens/${token}`).reply(200)
         supertest(getApp())
           .post(`/secure`)
           .send({
@@ -101,6 +104,7 @@ describe('secure controller', () => {
       before(done => {
         const token = 'invalid'
         nock(config.CONNECTOR_URL).get(`/v1/tokens/${token}/payment-request`).reply(404)
+        nock(config.CONNECTOR_URL).delete(`/v1/tokens/${token}`).reply(200)
         supertest(getApp())
           .post(`/secure`)
           .send({

--- a/app/setup/get.controller.js
+++ b/app/setup/get.controller.js
@@ -1,31 +1,35 @@
 'use strict'
 
 // NPM dependencies
-const lodash = require('lodash')
+const _ = require('lodash')
 
 // Local dependencies
 const countries = require('../../common/utils/countries')
+const {getSessionVariable} = require('../../common/config/cookies')
 
 module.exports = (req, res) => {
   const retrievedCountries = countries.retrieveCountries()
-  const paymentRequest = req.session.paymentRequest || {} // refactor this to a middleware and do not process the request if we don't have req.session.paymentRequest
+  const paymentRequestExternalId = req.params.paymentRequestExternalId
+  const session = getSessionVariable(req, paymentRequestExternalId)
+  const paymentRequest = session.paymentRequest
   const params = {
     countries: retrievedCountries,
-    paymentRequestExternalId: req.params.paymentRequestExternalId,
+    paymentRequestExternalId: paymentRequestExternalId,
     description: paymentRequest.description,
     amount: paymentRequest.amount
   }
-  if (!lodash.isEmpty(req.session.formValues)) {
+  const formValues = session.formValues
+  if (!_.isEmpty(formValues)) {
     // preselect country
     params.countries.forEach((country) => {
-      country.entry.selected = country.entry.country === req.session.formValues.country_code
+      country.entry.selected = country.entry.country === formValues.country_code
     })
     // set values to current view
-    params.formValues = req.session.formValues
-    params.validationErrors = req.session.validationErrors
+    params.formValues = formValues
+    params.validationErrors = session.validationErrors
     // clear form values from session
-    delete req.session.formValues
-    delete req.session.validationErrors
+    delete session.formValues
+    delete session.validationErrors
   }
   res.render('app/setup/get', params)
 }

--- a/app/setup/get.controller.tests.js
+++ b/app/setup/get.controller.tests.js
@@ -23,8 +23,7 @@ describe('setup get controller', () => {
       amount: amount,
       description: description
     })
-    const cookieHeader = new CookieBuilder()
-      .withPaymentRequest(paymentRequest)
+    const cookieHeader = new CookieBuilder(paymentRequest)
       .withCsrfSecret(csrfSecret)
       .build()
 
@@ -42,7 +41,6 @@ describe('setup get controller', () => {
     it('should return a 200 status code', () => {
       expect(response.statusCode).to.equal(200)
     })
-
     it('should display the enter direct debit page with correct description and amount', () => {
       expect($(`#payment-description`).text()).to.equal(description)
       expect($(`#amount`).text()).to.equal(`£1.00`)

--- a/app/setup/index.js
+++ b/app/setup/index.js
@@ -7,6 +7,7 @@ const express = require('express')
 const getController = require('./get.controller')
 const postController = require('./post.controller')
 const {validateAndRefreshCsrf, ensureSessionHasCsrfSecret} = require('../../common/middleware/csrf')
+const {ensureSessionHasPaymentRequest} = require('../../common/middleware/get-payment-request')
 
 // Initialisation
 const router = express.Router()
@@ -16,8 +17,8 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, getController)
-router.post(paths.index, validateAndRefreshCsrf, postController)
+router.get(paths.index, ensureSessionHasPaymentRequest, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, getController)
+router.post(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, postController)
 
 // Export
 module.exports = {

--- a/app/setup/post.controller.tests.js
+++ b/app/setup/post.controller.tests.js
@@ -32,8 +32,7 @@ describe('setup post controller', () => {
       external_id: paymentRequestExternalId
     })
     before(done => {
-      const cookieHeader = new CookieBuilder()
-        .withPaymentRequest(paymentRequest)
+      const cookieHeader = new CookieBuilder(paymentRequest)
         .withCsrfSecret('123')
         .build()
       supertest(getApp())
@@ -60,8 +59,7 @@ describe('setup post controller', () => {
     const csrfSecret = '123'
     const csrfToken = csrf().create(csrfSecret)
     before(done => {
-      const cookieHeader = new CookieBuilder()
-        .withPaymentRequest(paymentRequest)
+      const cookieHeader = new CookieBuilder(paymentRequest)
         .withCsrfSecret(csrfSecret)
         .build()
       const createPayerResponse = paymentFixtures.validCreatePayerResponse().getPlain()
@@ -119,8 +117,7 @@ describe('setup post controller', () => {
     })
     const csrfSecret = '123'
     const csrfToken = csrf().create(csrfSecret)
-    let cookieHeader
-    let $
+    let cookieHeader, $
     const formValues = {
       accountHolderName: 'Mr T',
       sortCode: '12 34 567',
@@ -135,8 +132,7 @@ describe('setup post controller', () => {
     }
 
     before(done => {
-      cookieHeader = new CookieBuilder()
-        .withPaymentRequest(paymentRequest)
+      cookieHeader = new CookieBuilder(paymentRequest)
         .withCsrfSecret(csrfSecret)
         .build()
       supertest(getApp())
@@ -162,7 +158,7 @@ describe('setup post controller', () => {
         .then(() => {
           supertest(getApp())
             .get(responseRedirect.header['location'])
-            .set('cookie', responseRedirect.header['set-cookie'])
+            .set('cookie', responseRedirect.header['set-cookie'][1])
             .end((err, res) => {
               $ = cheerio.load(res.text)
               done(err)
@@ -244,8 +240,7 @@ describe('setup post controller', () => {
     }
 
     before(done => {
-      cookieHeader = new CookieBuilder()
-        .withPaymentRequest(paymentRequest)
+      cookieHeader = new CookieBuilder(paymentRequest)
         .withCsrfSecret(csrfSecret)
         .build()
       supertest(getApp())
@@ -268,10 +263,9 @@ describe('setup post controller', () => {
         .then((response) => {
           supertest(getApp())
             .get(response.header['location'])
-            .set('cookie', response.header['set-cookie'])
+            .set('cookie', response.header['set-cookie'][1])
             .end((err, res) => {
               $ = cheerio.load(res.text)
-              console.log(res.text)
               done(err)
             })
         })

--- a/common/clients/base-client/wrapper.js
+++ b/common/clients/base-client/wrapper.js
@@ -15,7 +15,7 @@ module.exports = function (method, verb) {
     if (verb) opts.method = verb.toUpperCase()
     if (uri && !opts.uri && !opts.url) opts.uri = uri
     const context = {
-      correlationId: correlator.getId(),
+      correlationId: opts.correlationId || correlator.getId(),
       startTime: new Date(),
       url: joinURL(lodash.get(opts, 'baseUrl', ''), opts.url),
       method: opts.method,

--- a/common/clients/connector-client.js
+++ b/common/clients/connector-client.js
@@ -21,27 +21,29 @@ module.exports = {
   }
 }
 
-function retrievePaymentRequest (token) {
+function retrievePaymentRequest (token, correlationId) {
   return baseClient.get({
     headers,
     baseUrl,
     url: `/tokens/${token}/payment-request`,
     service: service,
+    correlationId: correlationId,
     description: `retrieve a payment request by its one-time token`
   }).then(paymentRequest => new PaymentRequest(paymentRequest))
 }
 
-function deleteToken (token) {
+function deleteToken (token, correlationId) {
   return baseClient.delete({
     headers,
     baseUrl,
     url: `/tokens/${token}`,
     service: service,
+    correlationId: correlationId,
     description: `delete a one-time token`
   })
 }
 
-function submitDirectDebitDetails (accountId, paymentRequestExternalId, body) {
+function submitDirectDebitDetails (accountId, paymentRequestExternalId, body, correlationId) {
   return baseClient.post({
     headers,
     baseUrl,
@@ -49,18 +51,20 @@ function submitDirectDebitDetails (accountId, paymentRequestExternalId, body) {
     url: `/api/accounts/${accountId}/payment-requests/${paymentRequestExternalId}/payers`,
     service: service,
     body: body,
+    correlationId: correlationId,
     description: `create a payer and store hashed bank account details`
   }).then(response => {
     return response.payer_external_id
   })
 }
-function confirmDirectDebitDetails (accountId, paymentRequestExternalId) {
+function confirmDirectDebitDetails (accountId, paymentRequestExternalId, correlationId) {
   return baseClient.post({
     headers,
     baseUrl,
     json: true,
     url: `/api/accounts/${accountId}/payment-requests/${paymentRequestExternalId}/confirm`,
     service: service,
+    correlationId: correlationId,
     description: `confirm a payment`
   })
 }

--- a/common/config/cookies.js
+++ b/common/config/cookies.js
@@ -1,24 +1,128 @@
 'use strict'
 
-const SESSION_ENCRYPTION_KEY = process.env.SESSION_ENCRYPTION_KEY
-const COOKIE_MAX_AGE_SESSION = process.env.COOKIE_MAX_AGE
+const clientSessions = require('client-sessions')
+const _ = require('lodash')
+const middlewareUtils = require('../../common/utils/middleware')
 
-if (!SESSION_ENCRYPTION_KEY) {
-  throw new Error('cookie encryption key is not set')
-}
+const {COOKIE_MAX_AGE, SESSION_ENCRYPTION_KEY, SESSION_ENCRYPTION_KEY_2, SECURE_COOKIE_OFF} = process.env
+const SESSION_COOKIE_NAME_1 = 'direct_debit_frontend_state'
+const SESSION_COOKIE_NAME_2 = 'direct_debit_frontend_state_2'
+const KEY_MIN_LENGTH = 10
 
-if (!COOKIE_MAX_AGE_SESSION) {
-  throw new Error('cookie max age is not set')
-}
-
-exports.session = {
-  cookieName: 'session', // cookie name dictates the key name added to the request object
-  secret: SESSION_ENCRYPTION_KEY,
-  duration: parseInt(COOKIE_MAX_AGE_SESSION), // how long the session will stay valid in ms
-  proxy: true,
-  cookie: {
-    ephemeral: false, // when true, cookie expires when the browser closes
-    httpOnly: true, // when true, cookie is not accessible from javascript
-    secureProxy: true
+function checkEnv () {
+  if (!isValidKey(SESSION_ENCRYPTION_KEY) && !isValidKey(SESSION_ENCRYPTION_KEY_2)) {
+    throw new Error('cookie encryption key is not set')
   }
+  if (!COOKIE_MAX_AGE) {
+    throw new Error('cookie max age is not set')
+  }
+}
+
+/**
+ * Returns valid client-sessions configuration for supplied
+ * cookie name and encryption key
+ **
+ * @param {string} name
+ * @param {string} key
+ *
+ * @returns {object}
+ * */
+function namedCookie (name, key) {
+  checkEnv()
+  return {
+    cookieName: name, // cookie name dictates the key name added to the request object
+    secret: key,
+    duration: parseInt(COOKIE_MAX_AGE), // how long the session will stay valid in ms
+    proxy: true,
+    cookie: {
+      ephemeral: false, // when true, cookie expires when the browser closes
+      httpOnly: true, // when true, cookie is not accessible from javascript
+      secureProxy: SECURE_COOKIE_OFF !== 'true'
+    }
+  }
+}
+/**
+ * @private
+ *
+ * @param {string} key
+ * @returns {boolean}
+ */
+function isValidKey (key) {
+  return !!key && typeof key === 'string' && key.length > KEY_MIN_LENGTH
+}
+/**
+ * Initialises app with client_sessions middleware.
+ * Configures one middleware per existing encryption key, to enable multiple
+ * keys to exist simultaneously, allowing key rotation.
+ *
+ * @param {Express.App} app
+ */
+function configureSessionCookie (app) {
+  checkEnv()
+  if (isValidKey(SESSION_ENCRYPTION_KEY)) app.use(middlewareUtils.excludingPaths(['/healthcheck'], clientSessions(namedCookie(SESSION_COOKIE_NAME_1, SESSION_ENCRYPTION_KEY))))
+  if (isValidKey(SESSION_ENCRYPTION_KEY_2)) app.use(middlewareUtils.excludingPaths(['/healthcheck'], clientSessions(namedCookie(SESSION_COOKIE_NAME_2, SESSION_ENCRYPTION_KEY_2))))
+}
+
+/**
+ * Sets session[key] = value for all valid sessions, based on existence of encryption key,
+ * and the existence of relevant cookie on the request
+ *
+ * @param {Request} req
+ * @param {string} key
+ * @param {*} value
+ */
+function setSessionVariable (req, key, value) {
+  if (SESSION_ENCRYPTION_KEY) {
+    setValueOnCookie(req, key, value, SESSION_COOKIE_NAME_1)
+  }
+
+  if (SESSION_ENCRYPTION_KEY_2) {
+    setValueOnCookie(req, key, value, SESSION_COOKIE_NAME_2)
+  }
+}
+
+/**
+ * Gets value of key from session, based on existence of encryption key
+ *
+ * @param {Request} req
+ * @param {string} key
+ * @returns {*}
+ */
+function getSessionVariable (req, key) {
+  const session = _.get(req, getSessionCookieName())
+  return session && session[key]
+}
+/**
+ * Returns current 'active' cookie name based on
+ * existing env vars. Favours `SESSION_ENCRYPTION_KEY`
+ * over `SESSION_ENCRYPTION_KEY_2`
+ *
+ * @returns {string}
+ */
+function getSessionCookieName () {
+  if (isValidKey(SESSION_ENCRYPTION_KEY)) {
+    return SESSION_COOKIE_NAME_1
+  } else if (isValidKey(SESSION_ENCRYPTION_KEY_2)) {
+    return SESSION_COOKIE_NAME_2
+  }
+}
+
+/**
+ * @private
+ *
+ * @param {object} req
+ * @param {string} key
+ * @param {*} value
+ * @param {string} cookieName
+ */
+function setValueOnCookie (req, key, value, cookieName) {
+  if (typeof _.get(req, `${cookieName}`) !== 'object') return
+  _.set(req, `${cookieName}.${key}`, value)
+}
+module.exports = {
+  namedCookie: namedCookie,
+  configureSessionCookie: configureSessionCookie,
+  getSessionCookieName: getSessionCookieName,
+  setSessionVariable: setSessionVariable,
+  getSessionVariable: getSessionVariable
 }

--- a/common/config/cookies.test.js
+++ b/common/config/cookies.test.js
@@ -1,0 +1,229 @@
+'use strict'
+
+// npm dependencies
+const {expect} = require('chai')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noPreserveCache()
+
+const getCookiesUtil = clientSessionsStub => {
+  if (clientSessionsStub) return proxyquire('../../common/config/cookies', {'client-sessions': clientSessionsStub})
+  return proxyquire('../../common/config/cookies', {})
+}
+
+describe('cookie configuration', function () {
+  describe('when setting the config', function () {
+    it('should configure cookie correctly', function () {
+      const app = {
+        use: sinon.stub()
+      }
+      const clientSessionsStub = sinon.stub()
+      const cookies = getCookiesUtil(clientSessionsStub)
+
+      const expectedConfig = {
+        cookieName: 'direct_debit_frontend_state',
+        proxy: true,
+        duration: 5400000,
+        secret: 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk',
+        cookie: {
+          ephemeral: false,
+          httpOnly: true,
+          secureProxy: true
+        }
+      }
+
+      cookies.configureSessionCookie(app)
+
+      expect(clientSessionsStub.calledWith(expectedConfig)).to.equal(true)
+    })
+    it('should configure two cookies if two session keys are set', function () {
+      const SESSION_ENCRYPTION_KEY_2 = process.env.SESSION_ENCRYPTION_KEY_2 = 'bobbobbobbob'
+      const app = {use: sinon.spy()}
+      const clientSessionsStub = sinon.stub()
+      const cookies = getCookiesUtil(clientSessionsStub)
+
+      const expectedConfig1 = {
+        cookieName: 'direct_debit_frontend_state',
+        proxy: true,
+        secret: process.env.SESSION_ENCRYPTION_KEY,
+        duration: 5400000,
+        cookie: {
+          ephemeral: false,
+          httpOnly: true,
+          secureProxy: true
+        }
+      }
+      const expectedConfig2 = {
+        cookieName: 'direct_debit_frontend_state_2',
+        proxy: true,
+        secret: SESSION_ENCRYPTION_KEY_2,
+        duration: 5400000,
+        cookie: {
+          ephemeral: false,
+          httpOnly: true,
+          secureProxy: true
+        }
+      }
+
+      cookies.configureSessionCookie(app)
+
+      expect(clientSessionsStub.calledWith(expectedConfig1)).to.equal(true)
+      expect(clientSessionsStub.calledWith(expectedConfig2)).to.equal(true)
+      expect(clientSessionsStub.callCount).to.equal(2)
+    })
+    it('should configure one cookie if one session keys is set', function () {
+      process.env.SESSION_ENCRYPTION_KEY_2 = ''
+      const app = {
+        use: sinon.spy()
+      }
+      const clientSessionsStub = sinon.stub()
+      const cookies = getCookiesUtil(clientSessionsStub)
+
+      const expectedConfig1 = {
+        cookieName: 'direct_debit_frontend_state',
+        proxy: true,
+        duration: 5400000,
+        secret: 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk',
+        cookie: {
+          ephemeral: false,
+          httpOnly: true,
+          secureProxy: true
+        }
+      }
+
+      cookies.configureSessionCookie(app)
+
+      expect(clientSessionsStub.calledWith(expectedConfig1)).to.equal(true)
+      expect(clientSessionsStub.callCount).to.equal(1)
+    })
+    it('should throw an error if no session keys are set', function () {
+      delete process.env.SESSION_ENCRYPTION_KEY_2
+      process.env.SESSION_ENCRYPTION_KEY = ''
+
+      const clientSessionsStub = sinon.stub()
+      const cookies = getCookiesUtil(clientSessionsStub)
+
+      expect(() => cookies.configureSessionCookie({})).to.throw(/cookie encryption key is not set/)
+    })
+    it('should throw an error if no valid session keys are set', function () {
+      process.env.SESSION_ENCRYPTION_KEY_2 = 'asfdwv'
+      process.env.SESSION_ENCRYPTION_KEY = ''
+
+      const clientSessionsStub = sinon.stub()
+      const cookies = getCookiesUtil(clientSessionsStub)
+
+      expect(() => cookies.configureSessionCookie({})).to.throw(/cookie encryption key is not set/)
+    })
+  })
+
+  describe('when setting value on session', function () {
+    it('should set value on direct_debit_frontend_state if SESSION_ENCRYPTION_KEY set', function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      process.env.SESSION_ENCRYPTION_KEY_2 = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      const cookies = getCookiesUtil()
+      const req = {
+        direct_debit_frontend_state: {}
+      }
+
+      cookies.setSessionVariable(req, 'foo', 'bar')
+
+      expect(req.direct_debit_frontend_state.foo).to.equal('bar')
+    })
+
+    it('should set value on direct_debit_frontend_state_2 if SESSION_ENCRYPTION_KEY_2 set', function () {
+      const originalKey = process.env.SESSION_ENCRYPTION_KEY
+      process.env.SESSION_ENCRYPTION_KEY = ''
+      process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2'
+
+      const cookies = getCookiesUtil()
+      const req = {
+        direct_debit_frontend_state_2: {}
+      }
+
+      cookies.setSessionVariable(req, 'foo', 'baz')
+
+      expect(req.direct_debit_frontend_state_2.foo).to.equal('baz')
+
+      process.env.SESSION_ENCRYPTION_KEY = originalKey
+
+      delete process.env.SESSION_ENCRYPTION_KEY_2
+    })
+
+    it('should set values on direct_debit_frontend_state and direct_debit_frontend_state_2 if both keys set', function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      process.env.SESSION_ENCRYPTION_KEY_2 = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+
+      const cookies = getCookiesUtil()
+      const req = {
+        direct_debit_frontend_state: {},
+        direct_debit_frontend_state_2: {}
+      }
+
+      cookies.setSessionVariable(req, 'foo', 'baz')
+
+      expect(req.direct_debit_frontend_state.foo).to.equal('baz')
+      expect(req.direct_debit_frontend_state_2.foo).to.equal('baz')
+
+      delete process.env.SESSION_ENCRYPTION_KEY_2
+    })
+
+    it('does not try to set value on non-existent cookie', function () {
+      const cookies = getCookiesUtil()
+      const req = {}
+
+      cookies.setSessionVariable(req, 'foo', 'bar')
+
+      expect(req).to.deep.equal({})
+    })
+  })
+
+  describe('getting value from session', function () {
+    it('should get value on frontend_state if only SESSION_ENCRYPTION_KEY set', function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      delete process.env.SESSION_ENCRYPTION_KEY_2
+      const cookies = getCookiesUtil()
+      const req = {
+        direct_debit_frontend_state: {
+          foo: 'bar'
+        }
+      }
+
+      expect(cookies.getSessionVariable(req, 'foo')).to.equal('bar')
+    })
+
+    it('should get value on frontend_state_2 if only SESSION_ENCRYPTION_KEY_2 set', function () {
+      const originalKey = process.env.SESSION_ENCRYPTION_KEY
+      delete process.env.SESSION_ENCRYPTION_KEY
+
+      process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2'
+
+      const cookies = getCookiesUtil()
+      const req = {
+        direct_debit_frontend_state_2: {
+          foo: 'baz'
+        }
+      }
+
+      expect(cookies.getSessionVariable(req, 'foo')).to.equal('baz')
+
+      process.env.SESSION_ENCRYPTION_KEY = originalKey
+      delete process.env.SESSION_ENCRYPTION_KEY_2
+    })
+
+    it('should get value from frontend_state if both keys set', function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      process.env.SESSION_ENCRYPTION_KEY_2 = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+
+      const cookies = getCookiesUtil()
+      const req = {
+        direct_debit_frontend_state: {
+          foo: 'bar'
+        },
+        direct_debit_frontend_state_2: {
+          foo: 'baz'
+        }
+      }
+
+      expect(cookies.getSessionVariable(req, 'foo')).to.equal('bar')
+    })
+  })
+})

--- a/common/middleware/csrf.tests.js
+++ b/common/middleware/csrf.tests.js
@@ -13,7 +13,7 @@ describe('CSRF', function () {
       .withArgs("it's a secret")
       .returns('newly-created token')
 
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf.js'),
+    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'),
       {'csrf': () => {
         return {
           verify: verify,
@@ -22,13 +22,20 @@ describe('CSRF', function () {
       }
       }).validateAndRefreshCsrf
 
+    const paymentRequestExternalId = 'aaaaa'
     const req = {
       route: {methods: {post: {}}},
-      session: {csrfSecret: "it's a secret"},
+      direct_debit_frontend_state: {
+        [paymentRequestExternalId]: {
+          csrfSecret: "it's a secret"
+        }
+      },
       body: {csrfToken: 'submitted token'}
     }
 
-    const res = {locals: {}}
+    const res = {locals: {
+      paymentRequestExternalId: paymentRequestExternalId
+    }}
 
     const next = sinon.spy()
 
@@ -40,8 +47,8 @@ describe('CSRF', function () {
 
   it('should error if session not present', function () {
     const renderErrorView = sinon.spy()
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf.js'), {
-      '../response.js': {
+    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'), {
+      '../response': {
         renderErrorView: renderErrorView
       }
     }).validateAndRefreshCsrf
@@ -62,8 +69,8 @@ describe('CSRF', function () {
 
   it('should error if session has no CSRF secret', function () {
     const renderErrorView = sinon.spy()
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf.js'), {
-      '../response.js': {
+    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'), {
+      '../response': {
         renderErrorView: renderErrorView
       }
     }).validateAndRefreshCsrf
@@ -88,8 +95,8 @@ describe('CSRF', function () {
     const verify = sinon.stub()
       .withArgs("it's a secret", 'forged token - call the police')
       .returns(false)
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf.js'), {
-      '../response.js': {
+    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'), {
+      '../response': {
         renderErrorView: renderErrorView
       },
       'csrf': () => {
@@ -123,7 +130,7 @@ describe('CSRF', function () {
       .withArgs("it's a secret")
       .returns('newly-created token')
 
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf.js'),
+    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'),
       {'csrf': () => {
         return {
           verify: verify,
@@ -132,13 +139,20 @@ describe('CSRF', function () {
       }
       }).validateAndRefreshCsrf
 
+    const paymentRequestExternalId = 'aaaaa'
     const req = {
       method: 'GET',
-      session: {csrfSecret: "it's a secret"},
+      direct_debit_frontend_state: {
+        [paymentRequestExternalId]: {
+          csrfSecret: "it's a secret"
+        }
+      },
       body: {csrfToken: "submitted forged token - but we don't really care"}
     }
 
-    const res = {locals: {}}
+    const res = {locals: {
+      paymentRequestExternalId: paymentRequestExternalId
+    }}
 
     const next = sinon.spy()
 

--- a/common/middleware/get-payment-request.js
+++ b/common/middleware/get-payment-request.js
@@ -1,0 +1,31 @@
+'use strict'
+const logger = require('pino')()
+
+// local dependencies
+const {renderErrorView} = require('../response')
+const {getSessionVariable} = require('../config/cookies')
+
+function ensureSessionHasPaymentRequest (req, res, next) {
+  const paymentRequestExternalId = req.params.paymentRequestExternalId
+
+  const session = getSessionVariable(req, paymentRequestExternalId)
+
+  if (!session) {
+    logger.error(`[${req.correlationId}] Session is not defined for ${paymentRequestExternalId}`)
+    return renderErrorView(req, res, 'There is a problem with the payments platform', 400)
+  }
+
+  const paymentRequest = session.paymentRequest
+
+  if (!paymentRequest) {
+    logger.error(`[${req.correlationId}] Could not retrieve payment request from session: ${paymentRequestExternalId}`)
+    return renderErrorView(req, res)
+  }
+  logger.info(`[${req.correlationId}] Retrieved payment request from session: ${paymentRequestExternalId}`)
+  res.locals.paymentRequestExternalId = paymentRequestExternalId
+  return next()
+}
+// Exports
+module.exports = {
+  ensureSessionHasPaymentRequest: ensureSessionHasPaymentRequest
+}

--- a/common/middleware/get-payment-request.tests.js
+++ b/common/middleware/get-payment-request.tests.js
@@ -1,0 +1,104 @@
+const path = require('path')
+const sinon = require('sinon')
+const assert = require('assert')
+const proxyquire = require('proxyquire')
+const _ = require('lodash')
+const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+
+describe('Get payment request middleware', function () {
+  it('should retrieve a payment request if present in the session', function () {
+    const paymentRequestExternalId = 'asdasdkjshfjdks'
+    const returnUrl = 'http://bla.test'
+    const gatewayAccountId = 23
+    const description = 'description'
+    const amount = 124
+    const type = 'CHARGE'
+    const state = 'SOME_STATE'
+    const paymentRequest = paymentFixtures.validPaymentRequest({
+      external_id: paymentRequestExternalId,
+      return_url: returnUrl,
+      gateway_account_id: gatewayAccountId,
+      description: description,
+      amount: amount,
+      type: type,
+      state: state
+    })
+    const req = {
+      params: {
+        paymentRequestExternalId: paymentRequestExternalId
+      },
+      direct_debit_frontend_state: {
+        [paymentRequestExternalId]: {
+          paymentRequest: paymentRequest
+        }
+      }
+    }
+
+    const res = {locals: {}}
+
+    const next = sinon.spy()
+    const getPaymentRequest = require('../../common/middleware/get-payment-request').ensureSessionHasPaymentRequest
+
+    getPaymentRequest(req, res, next)
+    const paymentRequestInSession = _.get(req, `direct_debit_frontend_state.${paymentRequestExternalId}`).paymentRequest
+    assert.equal(res.locals.paymentRequestExternalId, paymentRequestExternalId)
+    assert.equal(paymentRequestInSession.externalId, paymentRequestExternalId)
+    assert.equal(paymentRequestInSession.returnUrl, returnUrl)
+    assert.equal(paymentRequestInSession.gatewayAccountId, gatewayAccountId)
+    assert.equal(paymentRequestInSession.description, description)
+    assert.equal(paymentRequestInSession.amount, '1.24')
+    assert.equal(paymentRequestInSession.type, type)
+    assert.equal(paymentRequestInSession.state, state)
+    assert(next.calledOnce)
+  })
+
+  it('should error if session is not set for payment', function () {
+    const req = {
+      params: {
+        paymentRequestExternalId: 'someexternalid'
+      },
+      direct_debit_frontend_state: {
+        'anotherexternalid': {
+          paymentRequest: {}
+        }
+      }
+    }
+
+    const res = {locals: {}}
+
+    const next = sinon.spy()
+    const renderErrorView = sinon.spy()
+    const getPaymentRequest = proxyquire(path.join(__dirname, '/../../common/middleware/get-payment-request'), {
+      '../response': {
+        renderErrorView: renderErrorView
+      }
+    }).ensureSessionHasPaymentRequest
+    getPaymentRequest(req, res, next)
+
+    sinon.assert.calledWith(renderErrorView, req, res)
+  })
+
+  it('should error if session is set but payment is not in the session', function () {
+    const req = {
+      params: {
+        paymentRequestExternalId: 'someexternalid'
+      },
+      direct_debit_frontend_state: {
+        'someexternalid': {}
+      }
+    }
+
+    const res = {locals: {}}
+
+    const next = sinon.spy()
+    const renderErrorView = sinon.spy()
+    const getPaymentRequest = proxyquire(path.join(__dirname, '/../../common/middleware/get-payment-request'), {
+      '../response': {
+        renderErrorView: renderErrorView
+      }
+    }).ensureSessionHasPaymentRequest
+    getPaymentRequest(req, res, next)
+
+    sinon.assert.calledWith(renderErrorView, req, res)
+  })
+})

--- a/server.js
+++ b/server.js
@@ -15,13 +15,11 @@ const argv = require('minimist')(process.argv.slice(2))
 const staticify = require('staticify')(path.join(__dirname, 'public'))
 const compression = require('compression')
 const nunjucks = require('nunjucks')
-const clientSession = require('client-sessions')
 
 // Local dependencies
 const router = require('./app/router')
 const noCache = require('./common/utils/no-cache')
 const correlationHeader = require('./common/middleware/correlation-header')
-const middlwareUtils = require('./common/utils/middleware')
 const cookieConfig = require('./common/config/cookies')
 
 // Global constants
@@ -61,7 +59,7 @@ function initialiseGlobalMiddleware (app) {
   app.use('*', correlationHeader)
 }
 function initialiseCookies (app) {
-  app.use(middlwareUtils.excludingPaths(['/healthcheck'], clientSession(cookieConfig.session)))
+  cookieConfig.configureSessionCookie(app)
 }
 
 function initialiseI18n (app) {

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -52,12 +52,12 @@ module.exports = {
   validPaymentRequest: (opts = {}) => {
     const data = {
       external_id: opts.external_id || randomExternalId(),
-      return_url: randomUrl() || opts.return_url,
+      return_url: opts.return_url || randomUrl(),
       gateway_account_id: 23 || opts.gateway_account_id,
       description: opts.description || 'buy Silvia a coffee',
       amount: opts.amount || randomAmount(),
-      type: 'CHARGE' || opts.type,
-      state: 'NEW' || opts.state
+      type: opts.type || 'CHARGE',
+      state: opts.state || 'NEW'
     }
     return new PaymentRequest(data)
   }

--- a/test/test.env
+++ b/test/test.env
@@ -1,4 +1,6 @@
 CONNECTOR_URL=http://localhost:8004
 NODE_ENV=test
 COOKIE_MAX_AGE=5400000
-SESSION_ENCRYPTION_KEY=asdjhbwefbo23r23rbfik2roiwhefwbqw
+SESSION_ENCRYPTION_KEY=naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk
+SESSION_ENCRYPTION_KEY_2=asdjhbdefbo23r23rbfik2roiwhefwbqw
+SECURE_COOKIE_OFF=false


### PR DESCRIPTION
## WHAT
- We were sticking the payment journey's info (ie. payment request, form
  values, confirmation details) in `req.session`. This helped us move
  faster, but it won't allow multiple payments going through.
- This PR name spaces cookies on the payment request external id. So, for
  two payments from the same browser, the cookie will have the shape of:

```
 req: {
   direct_debit_frontend_state: {
       externalId1: {
          paymentRequest: [Object]
          ...
       },
       externalId2: {
          paymentRequest: [Another Object]
          ...
       }
   }
 }

```
- Introducing two session keys in similar fashion to cc frontend, this
  would allow us to rotate the encryption key of tokens. Session key 1
  is always favoured over 2, if present.
- Propagating request id to the dd client. Correlation id is present
  in all requests via a middleware, so `req.correlationId` is always
  populated
- GetPaymentRequest is now a middleware, making sure we have a payment
  request in the session, or we throw an error.

## HOW 
_Steps to test or reproduce:_
