### PR TITLE
BAU - nodeList cannot be iterated by forEach on Phantom

### DIFF
--- a/common/browsered/input-confirm.js
+++ b/common/browsered/input-confirm.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = () => {
-  const inputs = document.querySelectorAll('[data-confirmation]')
+  const inputs = Array.prototype.slice.call(document.querySelectorAll('[data-confirmation]'))
 
   inputs.forEach(input => {
     input.addEventListener('input', confirmInput, false)


### PR DESCRIPTION
This is old news but it gets forgotten. If you wrap it in this it
converts it into an array and it works fine

you could do it with a spread operator but this breaks it in old IE
