### PR TITLE
PP-3360 Fix back links for direct debit guarantee

### DIFF
--- a/app/direct-debit-guarantee/get.controller.js
+++ b/app/direct-debit-guarantee/get.controller.js
@@ -1,5 +1,9 @@
 'use strict'
 
 module.exports = (req, res) => {
-  res.render('app/direct-debit-guarantee/get')
+  const paymentRequestExternalId = req.params.paymentRequestExternalId
+  const params = {
+    paymentRequestExternalId
+  }
+  res.render('app/direct-debit-guarantee/get', params)
 }

--- a/app/direct-debit-guarantee/get.controller.tests.js
+++ b/app/direct-debit-guarantee/get.controller.tests.js
@@ -2,15 +2,55 @@
 
 // npm dependencies
 const supertest = require('supertest')
+const cheerio = require('cheerio')
+const chai = require('chai')
+const expect = chai.expect
 
 // Local dependencies
 const getApp = require('../../server').getApp
 
-describe('GET /direct-debit-guarantee page', function () {
-  it('should return HTTP 200 status', function (done) {
-    supertest(getApp())
-      .get('/direct-debit-guarantee')
-      .expect(200)
-      .end(done)
+describe('direct debit guarantee controller', () => {
+  describe('when requesting guarantee without a charge id', () => {
+    let response, $
+
+    before(done => {
+      supertest(getApp())
+        .get(`/direct-debit-guarantee`)
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+
+    it('should return a 200 status code', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+    it('should not display back links to the payment journey', () => {
+      expect($(`.back`).find('a').attr('href')).to.not.exist // eslint-disable-line no-unused-expressions
+      expect($(`.form-group`).find('a').attr('href')).to.not.exist // eslint-disable-line no-unused-expressions
+    })
+  })
+  describe('when requesting guarantee with a charge id', () => {
+    const paymentRequestExternalId = 'sdfihsdufh2e'
+    let response, $
+
+    before(done => {
+      supertest(getApp())
+        .get(`/direct-debit-guarantee/${paymentRequestExternalId}`)
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+
+    it('should return a 200 status code', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+    it('should display back links to the payment journey', () => {
+      expect($(`.back`).find('a').attr('href')).to.equal(`/setup/${paymentRequestExternalId}`)
+      expect($(`.form-group`).find('a').attr('href')).to.equal(`/setup/${paymentRequestExternalId}`)
+    })
   })
 })

--- a/app/direct-debit-guarantee/get.njk
+++ b/app/direct-debit-guarantee/get.njk
@@ -6,9 +6,11 @@
 
 {% block content %}
   <main id="content" role="main">
+  {% if paymentRequestExternalId %}
     <div class="back">
-      <a href="/setup" class="link-back">Back to payment</a>
+      <a href="/setup/{{paymentRequestExternalId}}" class="link-back">Back to payment</a>
     </div>
+  {% endif %}
     <div class="grid-row">
       <div class="column-two-thirds">
         <h1 class="heading-large">Direct Debit Guarantee</h1>
@@ -18,9 +20,11 @@
         <p>If an error is made in the payment of your Direct Debit, by GOV.UK Pay or your bank or building society, you are entitled to a full and immediate refund of the amount paid from your bank or building society.</p>
         <p>If you receive a refund you are not entitled to, you must pay it back when GOV.UK Pay asks you to.</p>
         <p>You can cancel a Direct Debit at any time by simply contacting your bank or building society. Written confirmation may be required. Please also notify GOV.UK Pay.</p>
+      {% if paymentRequestExternalId %}
         <div class="form-group">
-          <a href="/setup"><button class="button">Back to payment</button></a>
+          <a href="/setup/{{paymentRequestExternalId}}" class="button-link-back"><button class="button">Back to payment</button></a>
         </div>
+      {% endif %}
       </div>
     </div>
   </main>

--- a/app/direct-debit-guarantee/index.js
+++ b/app/direct-debit-guarantee/index.js
@@ -9,12 +9,15 @@ const getController = require('./get.controller')
 // Initialisation
 const router = express.Router()
 const indexPath = '/direct-debit-guarantee'
+const paymentJourneyPath = '/direct-debit-guarantee/:paymentRequestExternalId'
 const paths = {
-  index: indexPath
+  index: indexPath,
+  paymentJourney: paymentJourneyPath
 }
 
 // Routing
 router.get(paths.index, getController)
+router.get(paths.paymentJourney, getController)
 
 // Export
 module.exports = {

--- a/app/setup/get.controller.tests.js
+++ b/app/setup/get.controller.tests.js
@@ -47,7 +47,7 @@ describe('setup get controller', () => {
     })
 
     it('should display the enter direct debit page with a link to the direct debit guarantee', () => {
-      expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal('/direct-debit-guarantee')
+      expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal(`/direct-debit-guarantee/${paymentRequestExternalId}`)
     })
   })
 })

--- a/app/setup/get.njk
+++ b/app/setup/get.njk
@@ -112,7 +112,7 @@
     <div class="grid-row">
       <div class="column-two-thirds">
         <img src="/public/images/directdebit.png" class="direct-debit-logo" />
-        <p class="direct-debit-guarantee">Your payments are protected by the <a href="/direct-debit-guarantee">Direct Debit guarantee</a>.</p>
+        <p class="direct-debit-guarantee">Your payments are protected by the <a href="/direct-debit-guarantee/{{paymentRequestExternalId}}">Direct Debit guarantee</a>.</p>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## WHAT
 - If we are in a payment journey, we show back links bringing to the enter direct debit details page
 - If we are not in a payment journey (ie. link to the guarantee in an email sent to the user) we don't show back links because there's no "back" page to go to


## HOW 
_Steps to test or reproduce:_
