### PR TITLE
PP-3586 - added polyfill for closest to input-confirm

### DIFF
--- a/common/browsered/input-confirm.js
+++ b/common/browsered/input-confirm.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// Polyfills introduced as a temporary fix to make Smoketests pass. See PP-3489
+require('./polyfills')
+
 module.exports = () => {
   const inputs = Array.prototype.slice.call(document.querySelectorAll('[data-confirmation]'))
 


### PR DESCRIPTION
PhantomJS doesn’t like `.closest()` so we have to add the polyfill