### PR TITLE
PP-3586 Temporary fix for failing smoke tests

### DIFF
--- a/common/browsered/field-validation.js
+++ b/common/browsered/field-validation.js
@@ -3,9 +3,6 @@
 // NPM Dependencies
 const every = require('lodash/every')
 
-// Polyfills introduced as a temporary fix to make Smoketests pass. See PP-3489
-require('./polyfills')
-
 // Local Dependencies
 const checks = require('./field-validation-checks')
 

--- a/common/browsered/index.js
+++ b/common/browsered/index.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// Polyfills introduced as a temporary fix to make Smoketests pass. See PP-3489
+require('./polyfills')
+
 // NPM dependencies
 const $ = window.$ = window.jQuery = require('jquery') // Put this on window for cross compatability
 const analytics = require('gaap-analytics')

--- a/common/browsered/input-confirm.js
+++ b/common/browsered/input-confirm.js
@@ -1,8 +1,5 @@
 'use strict'
 
-// Polyfills introduced as a temporary fix to make Smoketests pass. See PP-3489
-require('./polyfills')
-
 module.exports = () => {
   const inputs = Array.prototype.slice.call(document.querySelectorAll('[data-confirmation]'))
 


### PR DESCRIPTION
## WHAT

Temporary fix for failing smoke tests because of the use the closest element not supported in PhantomJS.

A Polyfill for closest element has been embedded in the code which can be removed once smoke tests stop relying on phantomjs.

See https://github.com/alphagov/pay-selfservice/pull/702

with @ckalista
