### PR TITLE
PP-3586 Fix for flaky smoke tests

### DIFF
--- a/common/browsered/input-confirm.js
+++ b/common/browsered/input-confirm.js
@@ -1,6 +1,10 @@
 'use strict'
 
 module.exports = () => {
+  function insertAfter (newNode, referenceNode) {
+    referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling)
+  }
+
   const inputs = Array.prototype.slice.call(document.querySelectorAll('[data-confirmation]'))
 
   inputs.forEach(input => {
@@ -22,7 +26,8 @@ module.exports = () => {
           ${input.dataset.confirmationLabel}<span class="input-confirmation"></span>
         </p>
       </div>`
-      input.closest('.form-group').after(confirmation)
+      const formGroup = input.closest('.form-group')
+      insertAfter(confirmation, formGroup)
     }
 
     if (value === '') {


### PR DESCRIPTION
## WHAT
The email field has some Javscript validation that uses the `.after()` function which is unfortunately not supported in PhantomJS. Instead of introducing a polyfill here, the validation has simply been rewritten slightly not to use `.after()`.
