### PR TITLE
PP-3545 Expose gateway account

### DIFF
--- a/common/classes/GatewayAccount.class.js
+++ b/common/classes/GatewayAccount.class.js
@@ -1,0 +1,16 @@
+'use strict'
+
+class GatewayAccount {
+  constructor (opts) {
+    this.gatewayAccountId = opts.gateway_account_id
+    this.gatewayAccountExternalId = opts.gateway_account_external_id
+    this.paymentMethod = opts.payment_method
+    this.serviceName = opts.service_name
+    this.paymentProvider = opts.payment_provider
+    this.description = opts.description
+    this.type = opts.type
+    this.analyticsId = opts.analytics_id
+  }
+}
+
+module.exports = GatewayAccount

--- a/common/classes/PaymentRequest.class.js
+++ b/common/classes/PaymentRequest.class.js
@@ -5,13 +5,16 @@ class PaymentRequest {
     this.externalId = opts.external_id
     this.returnUrl = opts.return_url
     this.gatewayAccountId = opts.gateway_account_id
+    this.gatewayAccountExternalId = opts.gateway_account_external_id
     this.amount = penceToPounds(opts.amount)
     this.description = opts.description
     this.type = opts.type
     this.state = opts.state
   }
 }
-let penceToPounds = (pence) => {
+
+const penceToPounds = (pence) => {
   return (parseInt(pence) / 100).toFixed(2)
 }
+
 module.exports = PaymentRequest

--- a/common/clients/connector-client.js
+++ b/common/clients/connector-client.js
@@ -4,13 +4,16 @@
 const baseClient = require('./base-client/base-client')
 const {CONNECTOR_URL} = require('../config')
 const PaymentRequest = require('../../common/classes/PaymentRequest.class')
+const GatewayAccount = require('../../common/classes/GatewayAccount.class')
 
 const service = 'connector'
 const baseUrl = `${CONNECTOR_URL}/v1`
 const headers = {
 }
+
 // Exports
 module.exports = {
+  retrieveGatewayAccount,
   secure: {
     retrievePaymentRequest: retrievePaymentRequest,
     deleteToken: deleteToken
@@ -19,6 +22,17 @@ module.exports = {
     submitDirectDebitDetails: submitDirectDebitDetails,
     confirmDirectDebitDetails: confirmDirectDebitDetails
   }
+}
+
+function retrieveGatewayAccount (gatewayAccountId, correlationId) {
+  return baseClient.get({
+    headers,
+    baseUrl,
+    url: `/api/accounts/${gatewayAccountId}`,
+    service: service,
+    correlationId: correlationId,
+    description: `retrieve a gateway account`
+  }).then(gatewayAccount => new GatewayAccount(gatewayAccount))
 }
 
 function retrievePaymentRequest (token, correlationId) {
@@ -57,6 +71,7 @@ function submitDirectDebitDetails (accountId, paymentRequestExternalId, body, co
     return response.payer_external_id
   })
 }
+
 function confirmDirectDebitDetails (accountId, paymentRequestExternalId, correlationId) {
   return baseClient.post({
     headers,

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -3,19 +3,21 @@ const Payer = require('../../common/classes/Payer.class')
 const PaymentRequest = require('../../common/classes/PaymentRequest.class')
 // Create random values if none provided
 const randomExternalId = () => Math.random().toString(36).substring(7)
-const randomAmount = () => Math.round(Math.random() * 10000) + 1
+const randomNumber = () => Math.round(Math.random() * 10000) + 1
 const randomUrl = () => 'https://' + randomExternalId() + '.com'
 // todo add pactified
 module.exports = {
+
   validTokenExchangeResponse: (opts = {}) => {
     const data = {
       external_id: opts.external_id || randomExternalId(),
-      amount: opts.amount || randomAmount(),
+      amount: opts.amount || randomNumber(),
       description: opts.description || 'buy Silvia a coffee',
       type: opts.type || 'CHARGE',
-      state: opts.state || randomAmount(),
+      state: opts.state || randomNumber(),
       return_url: opts.return_url || randomUrl(),
-      gateway_account_id: opts.gatewayAccountId || randomAmount()
+      gateway_account_external_id: opts.gateway_account_external_id || randomExternalId(),
+      gateway_account_id: opts.gateway_account_id || randomNumber()
     }
     return {
       getPlain: () => {
@@ -23,6 +25,23 @@ module.exports = {
       }
     }
   },
+
+  validGatewayAccountResponse: (opts = {}) => {
+    const data = {
+      gatewayAccountId: opts.gatewayAccountId || randomNumber(),
+      gatewayAccountExternalId: opts.gatewayAccountExternalId || randomExternalId(),
+      paymentMethod: opts.paymentMethod || 'DIRECT_DEBIT',
+      serviceName: opts.serviceName || 'GOV.UK Direct Cake service',
+      paymentProvider: opts.paymentProvider || 'SANDBOX',
+      type: opts.type || 'TEST'
+    }
+    return {
+      getPlain: () => {
+        return data
+      }
+    }
+  },
+
   validCreatePayerResponse: (opts = {}) => {
     const data = {
       payer_external_id: opts.payer_external_id || randomExternalId()
@@ -33,6 +52,7 @@ module.exports = {
       }
     }
   },
+
   validPayer: (opts = {}) => {
     const data = {
       payer_external_id: opts.payer_external_id || randomExternalId(),
@@ -44,16 +64,18 @@ module.exports = {
     }
     return new Payer(data)
   },
+
   validPaymentRequest: (opts = {}) => {
     const data = {
       external_id: opts.external_id || randomExternalId(),
       return_url: opts.return_url || randomUrl(),
       gateway_account_id: 23 || opts.gateway_account_id,
       description: opts.description || 'buy Silvia a coffee',
-      amount: opts.amount || randomAmount(),
+      amount: opts.amount || randomNumber(),
       type: opts.type || 'CHARGE',
       state: opts.state || 'NEW'
     }
     return new PaymentRequest(data)
   }
+
 }


### PR DESCRIPTION
## WHAT

We need to expose gateway account to be able to distinguish between `TEST` and `LIVE` accounts as well as to get the service name to display in the header.

This PR adds the gatewayAccount to the session.

When we introduce Pact we need to cover the connector client with tests.