### PR TITLE
PP-3666 Remove openssl installation from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,4 @@ ADD . /app
 
 RUN ln -s /tmp/node_modules /app/node_modules
 
-RUN apk add openssl && \
-    mkdir -p bin && \
-    apk del --purge openssl
-
 CMD ./docker-startup.sh


### PR DESCRIPTION
## WHAT

When we initially integrated Chamber we needed openssl, not we use different way to connect with Chamber.
We don't need to install openssl this way anymore.

with @rhowe-gds
