### PR TITLE
PP-3649 Cancel links now work

### DIFF
--- a/app/cancel/get.controller.js
+++ b/app/cancel/get.controller.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const {renderErrorView} = require('../../common/response')
+const connectorClient = require('../../common/clients/connector-client')
+const {getSessionVariable} = require('../../common/config/cookies')
+
+module.exports = (req, res) => {
+  const paymentRequestExternalId = req.params.paymentRequestExternalId
+  const paymentRequest = getSessionVariable(req, paymentRequestExternalId).paymentRequest
+  const params = {
+    returnUrl: paymentRequest.returnUrl
+  }
+  connectorClient.payment.cancelPaymentRequest(paymentRequest.gatewayAccountExternalId, paymentRequestExternalId, req.correlationId)
+    .then(() => {
+      return res.render('app/cancel/get', params)
+    })
+    .catch(() => {
+      renderErrorView(req, res, 'No money has been taken from your account, please try again later.', 500)
+    })
+}

--- a/app/cancel/get.controller.tests.js
+++ b/app/cancel/get.controller.tests.js
@@ -1,0 +1,55 @@
+'use strict'
+
+// npm dependencies
+const chai = require('chai')
+const expect = chai.expect
+const supertest = require('supertest')
+const cheerio = require('cheerio')
+const nock = require('nock')
+const csrf = require('csrf')
+
+// Local dependencies
+const config = require('../../common/config')
+const getApp = require('../../server').getApp
+const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+const {CookieBuilder} = require('../../test/test_helpers/cookie-helper')
+let response, $
+const paymentRequestExternalId = 'sdfihsdufh2e'
+const paymentRequest = paymentFixtures.validPaymentRequest({
+  external_id: paymentRequestExternalId,
+  return_url: 'https://returnurl.test'
+})
+
+describe('cancel GET controller', () => {
+  const csrfSecret = '123'
+  const csrfToken = csrf().create(csrfSecret)
+  const cookieHeader = new CookieBuilder(paymentRequest)
+    .withCsrfSecret(csrfSecret)
+    .build()
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe('when cancelling a payment journey', () => {
+    before(done => {
+      nock(config.CONNECTOR_URL).post(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}/payment-requests/${paymentRequestExternalId}/cancel`).reply(200)
+      supertest(getApp())
+        .get(`/cancel/${paymentRequestExternalId}`)
+        .send({ 'csrfToken': csrfToken })
+        .set('cookie', cookieHeader)
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should return HTTP 200 status', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+
+    it('should display the user cancel page with a back link to the service', () => {
+      expect($('#return-url').attr('href')).to.equal('https://returnurl.test')
+    })
+  })
+})

--- a/app/cancel/get.njk
+++ b/app/cancel/get.njk
@@ -1,0 +1,16 @@
+{% extends "common/templates/layout.njk" %}
+
+{% block page_title %}
+  Your payment has been cancelled - GOV.UK Pay
+{% endblock %}
+
+{% block content %}
+  <main id="content" class="content-wrapper error-pages grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large user-cancel"> Your payment has been cancelled </h1>
+      <p class="lede">No money has been taken from your account</p>
+      <a id="return-url" href="{{ returnUrl }}" class="lede">Go back to the service</a>
+      <p>You can try to pay again</p>
+    </div>
+  </main>
+{% endblock %}

--- a/app/cancel/index.js
+++ b/app/cancel/index.js
@@ -1,0 +1,25 @@
+'use strict'
+
+// npm dependencies
+const express = require('express')
+
+// Local dependencies
+const getController = require('./get.controller')
+const {validateAndRefreshCsrf} = require('../../common/middleware/csrf')
+const {ensureSessionHasPaymentRequest} = require('../../common/middleware/get-payment-request')
+
+// Initialisation
+const router = express.Router()
+const indexPath = '/cancel/:paymentRequestExternalId'
+const paths = {
+  index: indexPath
+}
+
+// Routing
+router.get(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getController)
+
+// Export
+module.exports = {
+  router,
+  paths
+}

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -70,4 +70,8 @@ describe('confirmation get controller', function () {
   it('should display the enter confirmation page with bank statement description', () => {
     expect($(`#bank-statement-description`).text()).to.equal(`'${description}'`)
   })
+
+  it('should display the enter direct debit page with a link to cancel the payment', () => {
+    expect($(`.cancel-link`).attr('href')).to.equal(`/cancel/${paymentRequestExternalId}`)
+  })
 })

--- a/app/confirmation/get.njk
+++ b/app/confirmation/get.njk
@@ -41,7 +41,7 @@
           <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
           <div class="form-group">
             <button type="submit" id="submit-direct-debit" class="button">Confirm payment</button>
-            <a class="cancel-link" href="/setup/{{paymentRequestExternalId}}">Cancel payment</a>
+            <a class="cancel-link" href="/cancel/{{paymentRequestExternalId}}">Cancel payment</a>
           </div>
         </form>
       </div>

--- a/app/router.js
+++ b/app/router.js
@@ -4,6 +4,7 @@
 const healthcheck = require('./healthcheck')
 const secure = require('./secure')
 const setup = require('./setup')
+const cancel = require('./cancel')
 const directDebitGuarantee = require('./direct-debit-guarantee')
 const confirmation = require('./confirmation')
 
@@ -12,6 +13,7 @@ module.exports.bind = app => {
   app.use(healthcheck.router)
   app.use(secure.router)
   app.use(setup.router)
+  app.use(cancel.router)
   app.use(directDebitGuarantee.router)
   app.use(confirmation.router)
 }

--- a/app/setup/get.controller.tests.js
+++ b/app/setup/get.controller.tests.js
@@ -49,5 +49,9 @@ describe('setup get controller', () => {
     it('should display the enter direct debit page with a link to the direct debit guarantee', () => {
       expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal(`/direct-debit-guarantee/${paymentRequestExternalId}`)
     })
+
+    it('should display the enter direct debit page with a link to cancel the payment', () => {
+      expect($(`.cancel-link`).attr('href')).to.equal(`/cancel/${paymentRequestExternalId}`)
+    })
   })
 })

--- a/app/setup/get.njk
+++ b/app/setup/get.njk
@@ -97,7 +97,7 @@
 
           <div class="form-group">
             <button type="submit" id="submit-direct-debit-data" class="button">Continue</button>
-            <a class="cancel-link" href="/setup">Cancel payment</a>
+            <a class="cancel-link" href="/cancel/{{paymentRequestExternalId}}">Cancel payment</a>
           </div>
         </div>
       <aside class="payment-summary">

--- a/common/clients/connector-client.js
+++ b/common/clients/connector-client.js
@@ -20,7 +20,8 @@ module.exports = {
   },
   payment: {
     submitDirectDebitDetails: submitDirectDebitDetails,
-    confirmDirectDebitDetails: confirmDirectDebitDetails
+    confirmDirectDebitDetails: confirmDirectDebitDetails,
+    cancelPaymentRequest: cancelPaymentRequest
   }
 }
 
@@ -81,5 +82,15 @@ function confirmDirectDebitDetails (accountId, paymentRequestExternalId, correla
     service: service,
     correlationId: correlationId,
     description: `confirm a payment`
+  })
+}
+function cancelPaymentRequest (accountId, paymentRequestExternalId, correlationId) {
+  return baseClient.post({
+    headers,
+    baseUrl,
+    url: `/api/accounts/${accountId}/payment-requests/${paymentRequestExternalId}/cancel`,
+    service: service,
+    correlationId: correlationId,
+    description: `cancel a payment request`
   })
 }

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -70,6 +70,7 @@ module.exports = {
       external_id: opts.external_id || randomExternalId(),
       return_url: opts.return_url || randomUrl(),
       gateway_account_id: 23 || opts.gateway_account_id,
+      gateway_account_external_id: opts.gateway_account_external_id || randomExternalId(),
       description: opts.description || 'buy Silvia a coffee',
       amount: opts.amount || randomNumber(),
       type: opts.type || 'CHARGE',


### PR DESCRIPTION
## WHAT
 - Created a cancel controller which calls dd connector to cancel a payment journey. After
   the user presses cancel, we display a 'error' page explaining that no money was taken, and
   showing a link to the service (return url)

