### PR TITLE
PP-3670 Display service name on frontend

### DIFF
--- a/app/cancel/get.controller.tests.js
+++ b/app/cancel/get.controller.tests.js
@@ -19,6 +19,10 @@ const paymentRequest = paymentFixtures.validPaymentRequest({
   external_id: paymentRequestExternalId,
   return_url: 'https://returnurl.test'
 })
+const gatewayAccount = paymentFixtures.validGatewayAccount({
+  gateway_account_id: paymentRequest.gatewayAccountId,
+  gateway_account_external_id: paymentRequest.gatewayAccountExternalId
+})
 
 describe('cancel GET controller', () => {
   const csrfSecret = '123'
@@ -33,6 +37,7 @@ describe('cancel GET controller', () => {
   describe('when cancelling a payment journey', () => {
     before(done => {
       nock(config.CONNECTOR_URL).post(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}/payment-requests/${paymentRequestExternalId}/cancel`).reply(200)
+      nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}`).reply(200, gatewayAccount)
       supertest(getApp())
         .get(`/cancel/${paymentRequestExternalId}`)
         .send({ 'csrfToken': csrfToken })

--- a/app/cancel/index.js
+++ b/app/cancel/index.js
@@ -7,6 +7,7 @@ const express = require('express')
 const getController = require('./get.controller')
 const {validateAndRefreshCsrf} = require('../../common/middleware/csrf')
 const {ensureSessionHasPaymentRequest} = require('../../common/middleware/get-payment-request')
+const getGatewayAccount = require('../../common/middleware/get-gateway-account').middleware
 
 // Initialisation
 const router = express.Router()
@@ -16,7 +17,7 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getController)
+router.get(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getGatewayAccount, getController)
 
 // Export
 module.exports = {

--- a/app/change-payment-method/get.controller.tests.js
+++ b/app/change-payment-method/get.controller.tests.js
@@ -18,6 +18,10 @@ const paymentRequest = paymentFixtures.validPaymentRequest({
   external_id: paymentRequestExternalId,
   return_url: '/change-payment-method'
 })
+const gatewayAccount = paymentFixtures.validGatewayAccount({
+  gateway_account_id: paymentRequest.gatewayAccountId,
+  gateway_account_external_id: paymentRequest.gatewayAccountExternalId
+})
 
 describe('change-payment-method GET controller', () => {
   const csrfSecret = '123'
@@ -32,6 +36,7 @@ describe('change-payment-method GET controller', () => {
   describe('when switching payment options', () => {
     before(done => {
       nock(config.CONNECTOR_URL).post(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}/payment-requests/${paymentRequestExternalId}/change-payment-method`).reply(200)
+      nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}`).reply(200, gatewayAccount)
       supertest(getApp())
         .get(`/change-payment-method/${paymentRequestExternalId}`)
         .send({ 'csrfToken': csrfToken })

--- a/app/change-payment-method/index.js
+++ b/app/change-payment-method/index.js
@@ -7,6 +7,7 @@ const express = require('express')
 const getController = require('./get.controller')
 const {validateAndRefreshCsrf} = require('../../common/middleware/csrf')
 const {ensureSessionHasPaymentRequest} = require('../../common/middleware/get-payment-request')
+const getGatewayAccount = require('../../common/middleware/get-gateway-account').middleware
 
 // Initialisation
 const router = express.Router()
@@ -16,7 +17,7 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getController)
+router.get(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getGatewayAccount, getController)
 
 // Export
 module.exports = {

--- a/app/confirmation/index.js
+++ b/app/confirmation/index.js
@@ -8,6 +8,7 @@ const getController = require('./get.controller')
 const postController = require('./post.controller')
 const {validateAndRefreshCsrf} = require('../../common/middleware/csrf')
 const {ensureSessionHasPaymentRequest} = require('../../common/middleware/get-payment-request')
+const getGatewayAccount = require('../../common/middleware/get-gateway-account').middleware
 
 // Initialisation
 const router = express.Router()
@@ -17,8 +18,8 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getController)
-router.post(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, postController)
+router.get(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getGatewayAccount, getController)
+router.post(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getGatewayAccount, postController)
 
 // Export
 module.exports = {

--- a/app/confirmation/post.controller.tests.js
+++ b/app/confirmation/post.controller.tests.js
@@ -18,6 +18,10 @@ const paymentRequestExternalId = 'sdfihsdufh2e'
 const paymentRequest = paymentFixtures.validPaymentRequest({
   external_id: paymentRequestExternalId
 })
+const gatewayAccount = paymentFixtures.validGatewayAccount({
+  gateway_account_id: paymentRequest.gatewayAccountId,
+  gateway_account_external_id: paymentRequest.gatewayAccountExternalId
+})
 
 describe('confirmation POST controller', () => {
   const csrfSecret = '123'
@@ -32,6 +36,7 @@ describe('confirmation POST controller', () => {
   describe('when a payment is successfully confirmed', () => {
     before(done => {
       nock(config.CONNECTOR_URL).post(`/v1/api/accounts/${paymentRequest.gatewayAccountId}/payment-requests/${paymentRequestExternalId}/confirm`).reply(201)
+      nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}`).reply(200, gatewayAccount)
       supertest(getApp())
         .post(`/confirmation/${paymentRequestExternalId}`)
         .send({ 'csrfToken': csrfToken })
@@ -55,6 +60,8 @@ describe('confirmation POST controller', () => {
   describe('when failing to confirm a payment', () => {
     before(done => {
       nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${paymentRequest.gatewayAccountId}/payment-requests/${paymentRequestExternalId}/confirm`).reply(409)
+      nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}`).reply(200, gatewayAccount)
+
       supertest(getApp())
         .post(`/confirmation/${paymentRequestExternalId}`)
         .send({ 'csrfToken': csrfToken })

--- a/app/setup/index.js
+++ b/app/setup/index.js
@@ -8,6 +8,7 @@ const getController = require('./get.controller')
 const postController = require('./post.controller')
 const {validateAndRefreshCsrf, ensureSessionHasCsrfSecret} = require('../../common/middleware/csrf')
 const {ensureSessionHasPaymentRequest} = require('../../common/middleware/get-payment-request')
+const getGatewayAccount = require('../../common/middleware/get-gateway-account').middleware
 
 // Initialisation
 const router = express.Router()
@@ -17,8 +18,8 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, ensureSessionHasPaymentRequest, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, getController)
-router.post(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, postController)
+router.get(paths.index, ensureSessionHasPaymentRequest, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, getGatewayAccount, getController)
+router.post(paths.index, ensureSessionHasPaymentRequest, validateAndRefreshCsrf, getGatewayAccount, postController)
 
 // Export
 module.exports = {

--- a/app/setup/post.controller.tests.js
+++ b/app/setup/post.controller.tests.js
@@ -55,6 +55,10 @@ describe('setup post controller', () => {
     const paymentRequest = paymentFixtures.validPaymentRequest({
       external_id: paymentRequestExternalId
     })
+    const gatewayAccount = paymentFixtures.validGatewayAccount({
+      gateway_account_id: paymentRequest.gatewayAccountId,
+      gateway_account_external_id: paymentRequest.gatewayAccountExternalId
+    })
     const formValues = paymentFixtures.validPayer()
     const csrfSecret = '123'
     const csrfToken = csrf().create(csrfSecret)
@@ -63,6 +67,7 @@ describe('setup post controller', () => {
         .withCsrfSecret(csrfSecret)
         .build()
       const createPayerResponse = paymentFixtures.validCreatePayerResponse().getPlain()
+      nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}`).reply(200, gatewayAccount)
       nock(config.CONNECTOR_URL)
         .post(`/v1/api/accounts/${paymentRequest.gatewayAccountId}/payment-requests/${paymentRequestExternalId}/payers`, {
           account_holder_name: formValues.accountHolderName,
@@ -105,6 +110,10 @@ describe('setup post controller', () => {
     const paymentRequest = paymentFixtures.validPaymentRequest({
       external_id: paymentRequestExternalId
     })
+    const gatewayAccount = paymentFixtures.validGatewayAccount({
+      gateway_account_id: paymentRequest.gatewayAccountId,
+      gateway_account_external_id: paymentRequest.gatewayAccountExternalId
+    })
     const csrfSecret = '123'
     const csrfToken = csrf().create(csrfSecret)
     let cookieHeader, $
@@ -120,6 +129,7 @@ describe('setup post controller', () => {
       cookieHeader = new CookieBuilder(paymentRequest)
         .withCsrfSecret(csrfSecret)
         .build()
+      nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}`).reply(200, gatewayAccount)
       supertest(getApp())
         .post(`/setup/${paymentRequestExternalId}`)
         .send({ 'csrfToken': csrfToken,
@@ -183,6 +193,10 @@ describe('setup post controller', () => {
     let paymentRequest = paymentFixtures.validPaymentRequest({
       external_id: paymentRequestExternalId
     })
+    const gatewayAccount = paymentFixtures.validGatewayAccount({
+      gateway_account_id: paymentRequest.gatewayAccountId,
+      gateway_account_external_id: paymentRequest.gatewayAccountExternalId
+    })
     const csrfSecret = '123'
     const csrfToken = csrf().create(csrfSecret)
     let cookieHeader
@@ -198,6 +212,7 @@ describe('setup post controller', () => {
       cookieHeader = new CookieBuilder(paymentRequest)
         .withCsrfSecret(csrfSecret)
         .build()
+      nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${paymentRequest.gatewayAccountExternalId}`).reply(200, gatewayAccount)
       supertest(getApp())
         .post(`/setup/${paymentRequestExternalId}`)
         .send({ 'csrfToken': csrfToken,

--- a/app/setup/post.controller.tests.js
+++ b/app/setup/post.controller.tests.js
@@ -190,7 +190,7 @@ describe('setup post controller', () => {
   describe('Submitting the form with validation errors displays an error summary with respective links', () => {
     const paymentRequestExternalId = 'wsfihsdufh2g'
     let $
-    let paymentRequest = paymentFixtures.validPaymentRequest({
+    const paymentRequest = paymentFixtures.validPaymentRequest({
       external_id: paymentRequestExternalId
     })
     const gatewayAccount = paymentFixtures.validGatewayAccount({

--- a/common/middleware/get-gateway-account.js
+++ b/common/middleware/get-gateway-account.js
@@ -13,7 +13,7 @@ const connectorClient = require('../clients/connector-client')
 const CACHE_MAX_AGE = parseInt(process.env.CACHE_MAX_AGE || 15 * 60 * 1000) // default to 15 mins
 const cache = new Cache()
 
-function middleware(req, res, next) {
+function middleware (req, res, next) {
   const paymentRequest = _.get(req, 'res.locals.paymentRequest')
   if (!paymentRequest) {
     logger.error(`[${req.correlationId}] Could not retrieve payment request from res.locals`)
@@ -39,7 +39,7 @@ function middleware(req, res, next) {
   }
 }
 
-module.exports = { 
-  CACHE_MAX_AGE, 
-  middleware 
+module.exports = {
+  CACHE_MAX_AGE,
+  middleware
 }

--- a/common/middleware/get-gateway-account.js
+++ b/common/middleware/get-gateway-account.js
@@ -1,0 +1,45 @@
+'use strict'
+
+// npm dependencies
+const _ = require('lodash')
+const logger = require('pino')()
+const {Cache} = require('memory-cache')
+
+// local dependencies
+const {renderErrorView} = require('../response')
+const connectorClient = require('../clients/connector-client')
+
+// constants
+const CACHE_MAX_AGE = parseInt(process.env.CACHE_MAX_AGE || 15 * 60 * 1000) // default to 15 mins
+const cache = new Cache()
+
+function middleware(req, res, next) {
+  const paymentRequest = _.get(req, 'res.locals.paymentRequest')
+  if (!paymentRequest) {
+    logger.error(`[${req.correlationId}] Could not retrieve payment request from res.locals`)
+    return renderErrorView(req, res)
+  }
+
+  const gatewayAccountExternalId = paymentRequest.gatewayAccountExternalId
+  const cachedGatewayAccount = cache.get(gatewayAccountExternalId)
+  if (cachedGatewayAccount) {
+    res.locals.gatewayAccount = cachedGatewayAccount
+    next()
+  } else {
+    connectorClient.retrieveGatewayAccount(gatewayAccountExternalId, req.correlationId)
+      .then(gatewayAccount => {
+        cache.put(gatewayAccountExternalId, gatewayAccount, CACHE_MAX_AGE)
+        res.locals.gatewayAccount = gatewayAccount
+        next()
+      })
+      .catch(() => {
+        logger.error(`[${req.correlationId}] Could not load gateway account from connector: ${gatewayAccountExternalId}`)
+        renderErrorView(req, res)
+      })
+  }
+}
+
+module.exports = { 
+  CACHE_MAX_AGE, 
+  middleware 
+}

--- a/common/middleware/get-gateway-account.tests.js
+++ b/common/middleware/get-gateway-account.tests.js
@@ -30,7 +30,7 @@ const setup = () => {
 
 describe('Get gateway account middleware', () => {
   describe('when the payment request is not found in res.locals', () => {
-    let {req, res, next, renderErrorView, getGatewayAccount} = setup()
+    const {req, res, next, renderErrorView, getGatewayAccount} = setup()
 
     before(() => {
       getGatewayAccount.middleware(req, res, next)
@@ -42,7 +42,7 @@ describe('Get gateway account middleware', () => {
   })
 
   describe('when the gateway account is cached', () => {
-    let {req, res, next, cache, getGatewayAccount} = setup()
+    const {req, res, next, cache, getGatewayAccount} = setup()
 
     before(() => {
       req.res.locals = {paymentRequest: PAYMENT_REQUEST}
@@ -61,7 +61,7 @@ describe('Get gateway account middleware', () => {
 
   describe('when the gateway account is not cached', () => {
     describe('and the gateway account can be retrieved from connector', () => {
-      let {req, res, next, cache, connectorClient, getGatewayAccount} = setup()
+      const {req, res, next, cache, connectorClient, getGatewayAccount} = setup()
 
       before(() => {
         req.res.locals = {paymentRequest: PAYMENT_REQUEST}

--- a/common/middleware/get-gateway-account.tests.js
+++ b/common/middleware/get-gateway-account.tests.js
@@ -1,0 +1,105 @@
+const _ = require('lodash')
+const sinon = require('sinon')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+const path = require('path')
+const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+
+const PAYMENT_REQUEST = paymentFixtures.validPaymentRequest()
+const GATEWAY_ACCOUNT = paymentFixtures.validGatewawyAccount({
+  gateway_account_id: PAYMENT_REQUEST.gatewayAccountId,
+  gateway_account_external_id: PAYMENT_REQUEST.gatewayAccountExternalId
+})
+
+const setup = () => {
+  const fixtures = {
+    req: {res: {locals: {}}, correlationId: 'correlation-id'},
+    res: {locals: {}},
+    next: sinon.spy(),
+    cache: { get: sinon.stub(), put: sinon.spy() }, 
+    connectorClient: {retrieveGatewayAccount: sinon.stub()},
+    renderErrorView: sinon.spy()
+  }
+
+  const getGatewayAccount = proxyquire('./get-gateway-account', {
+    '../response': {renderErrorView: fixtures.renderErrorView},
+    'memory-cache': { Cache: function() { return fixtures.cache } },
+    '../clients/connector-client': fixtures.connectorClient
+  })
+
+  return Object.assign(fixtures, {getGatewayAccount})
+}
+
+describe.only('Get gateway account middleware', () => {
+  describe('when the payment request is not found in res.locals', () => {
+    let {req, res, next, renderErrorView, getGatewayAccount} = setup()
+
+    before(() => {
+      getGatewayAccount.middleware(req, res, next)
+    })
+
+    it('should return an error', () => {
+      sinon.assert.calledWith(renderErrorView, req, res)
+    })
+  })
+
+  describe('when the gateway account is cached', () => {
+    let {req, res, next, cache, getGatewayAccount} = setup()
+
+    before(() => {
+      req.res.locals = {paymentRequest: PAYMENT_REQUEST}
+      cache.get.withArgs(PAYMENT_REQUEST.gatewayAccountExternalId).returns(GATEWAY_ACCOUNT)
+      getGatewayAccount.middleware(req, res, next)
+    })
+
+    it('should set the cached gateway account in res.locals', () => {
+      expect(res.locals).to.have.property('gatewayAccount', GATEWAY_ACCOUNT)
+    })
+
+    it('should call the next callback method', () => {
+      sinon.assert.calledOn(next)
+    })
+  })
+
+  describe('when the gateway account is not cached', () => {
+    describe('and the gateway account can be retrieved from connector', () => {
+      let {req, res, next, cache, connectorClient, getGatewayAccount} = setup()
+
+      before(() => {
+        req.res.locals = {paymentRequest: PAYMENT_REQUEST}
+        connectorClient.retrieveGatewayAccount
+          .withArgs(PAYMENT_REQUEST.gatewayAccountExternalId, req.correlationId)
+          .returns(Promise.resolve(GATEWAY_ACCOUNT))
+        getGatewayAccount.middleware(req, res, next)
+      })
+
+      it('should cache the gateway account', () => {
+        sinon.assert.calledWith(cache.put, PAYMENT_REQUEST.gatewayAccountExternalId, GATEWAY_ACCOUNT, getGatewayAccount.CACHE_MAX_AGE)
+      })
+
+      it('should set the gateway account that has been retrieved in res.locals', () => {
+        expect(res.locals).to.have.property('gatewayAccount', GATEWAY_ACCOUNT)
+      })
+
+      it('should call the next callback method', () => {
+        sinon.assert.calledOn(next)
+      })
+    })
+
+    describe('and the gateway account can not be retrieved from connector', () => {
+      let {req, res, next, connectorClient, renderErrorView, getGatewayAccount} = setup()
+
+      before(() => {
+        req.res.locals = {paymentRequest: PAYMENT_REQUEST}
+        connectorClient.retrieveGatewayAccount
+          .withArgs(PAYMENT_REQUEST.gatewayAccountExternalId, req.correlationId)
+          .returns(Promise.reject())
+        getGatewayAccount.middleware(req, res, next)
+      })
+
+      it('should return an error', () => {
+        sinon.assert.calledWith(renderErrorView, req, res)
+      })
+    })
+  })
+})

--- a/common/middleware/get-gateway-account.tests.js
+++ b/common/middleware/get-gateway-account.tests.js
@@ -1,12 +1,10 @@
-const _ = require('lodash')
 const sinon = require('sinon')
 const {expect} = require('chai')
 const proxyquire = require('proxyquire')
-const path = require('path')
 const paymentFixtures = require('../../test/fixtures/payments-fixtures')
 
 const PAYMENT_REQUEST = paymentFixtures.validPaymentRequest()
-const GATEWAY_ACCOUNT = paymentFixtures.validGatewawyAccount({
+const GATEWAY_ACCOUNT = paymentFixtures.validGatewayAccount({
   gateway_account_id: PAYMENT_REQUEST.gatewayAccountId,
   gateway_account_external_id: PAYMENT_REQUEST.gatewayAccountExternalId
 })
@@ -16,21 +14,21 @@ const setup = () => {
     req: {res: {locals: {}}, correlationId: 'correlation-id'},
     res: {locals: {}},
     next: sinon.spy(),
-    cache: { get: sinon.stub(), put: sinon.spy() }, 
+    cache: { get: sinon.stub(), put: sinon.spy() },
     connectorClient: {retrieveGatewayAccount: sinon.stub()},
     renderErrorView: sinon.spy()
   }
 
   const getGatewayAccount = proxyquire('./get-gateway-account', {
     '../response': {renderErrorView: fixtures.renderErrorView},
-    'memory-cache': { Cache: function() { return fixtures.cache } },
+    'memory-cache': { Cache: function () { return fixtures.cache } },
     '../clients/connector-client': fixtures.connectorClient
   })
 
   return Object.assign(fixtures, {getGatewayAccount})
 }
 
-describe.only('Get gateway account middleware', () => {
+describe('Get gateway account middleware', () => {
   describe('when the payment request is not found in res.locals', () => {
     let {req, res, next, renderErrorView, getGatewayAccount} = setup()
 
@@ -93,7 +91,7 @@ describe.only('Get gateway account middleware', () => {
         req.res.locals = {paymentRequest: PAYMENT_REQUEST}
         connectorClient.retrieveGatewayAccount
           .withArgs(PAYMENT_REQUEST.gatewayAccountExternalId, req.correlationId)
-          .returns(Promise.reject())
+          .returns(Promise.reject(new Error()))
         getGatewayAccount.middleware(req, res, next)
       })
 

--- a/common/middleware/get-payment-request.js
+++ b/common/middleware/get-payment-request.js
@@ -23,6 +23,7 @@ function ensureSessionHasPaymentRequest (req, res, next) {
   }
   logger.info(`[${req.correlationId}] Retrieved payment request from session: ${paymentRequestExternalId}`)
   res.locals.paymentRequestExternalId = paymentRequestExternalId
+  res.locals.paymentRequest = paymentRequest
   return next()
 }
 // Exports

--- a/common/middleware/get-payment-request.js
+++ b/common/middleware/get-payment-request.js
@@ -28,5 +28,5 @@ function ensureSessionHasPaymentRequest (req, res, next) {
 }
 // Exports
 module.exports = {
-  ensureSessionHasPaymentRequest: ensureSessionHasPaymentRequest
+  ensureSessionHasPaymentRequest
 }

--- a/common/middleware/get-payment-request.tests.js
+++ b/common/middleware/get-payment-request.tests.js
@@ -42,13 +42,8 @@ describe('Get payment request middleware', function () {
     getPaymentRequest(req, res, next)
     const paymentRequestInSession = _.get(req, `direct_debit_frontend_state.${paymentRequestExternalId}`).paymentRequest
     assert.equal(res.locals.paymentRequestExternalId, paymentRequestExternalId)
-    assert.equal(paymentRequestInSession.externalId, paymentRequestExternalId)
-    assert.equal(paymentRequestInSession.returnUrl, returnUrl)
-    assert.equal(paymentRequestInSession.gatewayAccountId, gatewayAccountId)
-    assert.equal(paymentRequestInSession.description, description)
-    assert.equal(paymentRequestInSession.amount, '1.24')
-    assert.equal(paymentRequestInSession.type, type)
-    assert.equal(paymentRequestInSession.state, state)
+    assert.deepEqual(res.locals.paymentRequest, paymentRequest)
+    assert.deepEqual(paymentRequestInSession, paymentRequest)
     assert(next.calledOnce)
   })
 

--- a/common/templates/includes/propositional_navigation.njk
+++ b/common/templates/includes/propositional_navigation.njk
@@ -1,0 +1,7 @@
+<div class="header-proposition">
+  <div class="content">
+    <nav id="proposition-menu">
+      <span id="proposition-name">{{ gatewayAccount.serviceName }}</span>
+    </nav>
+  </div>
+</div>

--- a/common/templates/layout.njk
+++ b/common/templates/layout.njk
@@ -11,6 +11,12 @@
   {% include "common/templates/includes/analytics.njk" %}
 {% endblock %}
 
+{% block proposition_header %}
+  {% include "common/templates/includes/propositional_navigation.njk" %}
+{% endblock %}
+
+{% block header_class %}with-proposition{% endblock %}
+
 {% block cookie_message %}
   {% include "common/templates/includes/cookies.njk" %}
 {% endblock %}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -224,10 +224,10 @@
       "from": "async-each@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
     },
-    "async-listener": {
-      "version": "0.6.9",
-      "from": "async-listener@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.9.tgz"
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "from": "async-hook-jl@>=1.7.6 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz"
     },
     "asynckit": {
       "version": "0.4.0",
@@ -240,9 +240,9 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
     },
     "aws4": {
-      "version": "1.6.0",
+      "version": "1.7.0",
       "from": "aws4@>=1.6.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz"
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -301,9 +301,9 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
     },
     "chalk": {
-      "version": "2.3.2",
+      "version": "2.4.1",
       "from": "chalk@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz"
     },
     "chokidar": {
       "version": "1.7.0",
@@ -320,6 +320,11 @@
       "from": "cliui@>=3.0.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "from": "cls-hooked@>=4.2.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz"
+    },
     "co": {
       "version": "4.6.0",
       "from": "co@>=4.6.0 <5.0.0",
@@ -329,11 +334,6 @@
       "version": "1.1.0",
       "from": "code-point-at@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-    },
-    "coffee-script": {
-      "version": "1.12.7",
-      "from": "coffee-script@>=1.12.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz"
     },
     "color-convert": {
       "version": "1.9.1",
@@ -375,11 +375,6 @@
       "from": "content-type@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
     },
-    "continuation-local-storage": {
-      "version": "3.2.1",
-      "from": "continuation-local-storage@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz"
-    },
     "cookie": {
       "version": "0.3.1",
       "from": "cookie@0.3.1",
@@ -401,9 +396,9 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "correlation-id": {
-      "version": "2.0.0",
+      "version": "2.1.2",
       "from": "correlation-id@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/correlation-id/-/correlation-id-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/correlation-id/-/correlation-id-2.1.2.tgz"
     },
     "cryptiles": {
       "version": "3.1.2",
@@ -418,9 +413,9 @@
       }
     },
     "csextends": {
-      "version": "1.1.1",
+      "version": "1.2.0",
       "from": "csextends@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/csextends/-/csextends-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/csextends/-/csextends-1.2.0.tgz"
     },
     "csrf": {
       "version": "3.0.6",
@@ -480,12 +475,12 @@
     },
     "emitter-listener": {
       "version": "1.1.1",
-      "from": "emitter-listener@>=1.1.1 <2.0.0",
+      "from": "emitter-listener@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.1.tgz"
     },
     "encodeurl": {
       "version": "1.0.2",
-      "from": "encodeurl@>=1.0.1 <1.1.0",
+      "from": "encodeurl@>=1.0.2 <1.1.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
     },
     "end-of-stream": {
@@ -519,19 +514,14 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
     "express": {
-      "version": "4.16.2",
+      "version": "4.16.3",
       "from": "express@>=4.16.0 <4.17.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "dependencies": {
-        "setprototypeof": {
-          "version": "1.1.0",
-          "from": "setprototypeof@1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
-        },
         "statuses": {
-          "version": "1.3.1",
-          "from": "statuses@>=1.3.1 <1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          "version": "1.4.0",
+          "from": "statuses@>=1.4.0 <1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
         }
       }
     },
@@ -605,14 +595,14 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "finalhandler": {
-      "version": "1.1.0",
-      "from": "finalhandler@1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "version": "1.1.1",
+      "from": "finalhandler@1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "dependencies": {
         "statuses": {
-          "version": "1.3.1",
-          "from": "statuses@>=1.3.1 <1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          "version": "1.4.0",
+          "from": "statuses@>=1.4.0 <1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
         }
       }
     },
@@ -652,21 +642,15 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
     },
     "fsevents": {
-      "version": "1.1.3",
+      "version": "1.2.3",
       "from": "fsevents@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
       "optional": true,
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
-          "from": "abbrev@1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "from": "ajv@4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "version": "1.1.1",
+          "from": "abbrev@1.1.1",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "optional": true
         },
         "ansi-regex": {
@@ -675,9 +659,9 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
         },
         "aproba": {
-          "version": "1.1.1",
-          "from": "aproba@1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "version": "1.2.0",
+          "from": "aproba@1.2.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "optional": true
         },
         "are-we-there-yet": {
@@ -686,88 +670,26 @@
           "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
           "optional": true
         },
-        "asn1": {
-          "version": "0.2.3",
-          "from": "asn1@0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "from": "assert-plus@0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "from": "asynckit@0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "from": "aws4@1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "optional": true
-        },
         "balanced-match": {
-          "version": "0.4.2",
-          "from": "balanced-match@0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "from": "bcrypt-pbkdf@1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "optional": true
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "from": "block-stream@0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
-        },
-        "boom": {
-          "version": "2.10.1",
-          "from": "boom@2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+          "version": "1.0.0",
+          "from": "balanced-match@1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
         },
         "brace-expansion": {
-          "version": "1.1.7",
-          "from": "brace-expansion@1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+          "version": "1.1.11",
+          "from": "brace-expansion@1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
         },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "from": "buffer-shims@1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "from": "caseless@0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "from": "co@4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+        "chownr": {
+          "version": "1.0.1",
+          "from": "chownr@1.0.1",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "from": "code-point-at@1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
         "concat-map": {
           "version": "0.0.1",
@@ -782,31 +704,13 @@
         "core-util-is": {
           "version": "1.0.2",
           "from": "core-util-is@1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "from": "cryptiles@2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "from": "dashdash@1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "optional": true
         },
         "debug": {
-          "version": "2.6.8",
-          "from": "debug@2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "version": "2.6.9",
+          "from": "debug@2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "optional": true
         },
         "deep-extend": {
@@ -815,11 +719,6 @@
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
           "optional": true
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
         "delegates": {
           "version": "1.0.0",
           "from": "delegates@1.0.0",
@@ -827,54 +726,21 @@
           "optional": true
         },
         "detect-libc": {
-          "version": "1.0.2",
-          "from": "detect-libc@^1.0.2",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+          "version": "1.0.3",
+          "from": "detect-libc@1.0.3",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "optional": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "from": "ecc-jsbn@0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "optional": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "from": "extend@3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "from": "extsprintf@1.0.2",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "from": "form-data@2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+        "fs-minipass": {
+          "version": "1.2.5",
+          "from": "fs-minipass@1.2.5",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0",
           "from": "fs.realpath@1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "from": "fstream@1.0.11",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "from": "fstream-ignore@1.0.5",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "optional": true
         },
         "gauge": {
@@ -883,40 +749,10 @@
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "optional": true
         },
-        "getpass": {
-          "version": "0.1.7",
-          "from": "getpass@0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
-        },
         "glob": {
           "version": "7.1.2",
           "from": "glob@7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "from": "graceful-fs@4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "from": "har-schema@1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "from": "har-validator@4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "optional": true
         },
         "has-unicode": {
@@ -925,26 +761,23 @@
           "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "optional": true
         },
-        "hawk": {
-          "version": "3.1.3",
-          "from": "hawk@3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+        "iconv-lite": {
+          "version": "0.4.21",
+          "from": "iconv-lite@0.4.21",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+          "optional": true
         },
-        "hoek": {
-          "version": "4.2.1",
-          "from": "hoek@2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz"
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "from": "http-signature@1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+        "ignore-walk": {
+          "version": "3.0.1",
+          "from": "ignore-walk@3.0.1",
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "optional": true
         },
         "inflight": {
           "version": "1.0.6",
           "from": "inflight@1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "optional": true
         },
         "inherits": {
           "version": "2.0.3",
@@ -952,9 +785,9 @@
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
         },
         "ini": {
-          "version": "1.3.4",
-          "from": "ini@1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "version": "1.3.5",
+          "from": "ini@1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "optional": true
         },
         "is-fullwidth-code-point": {
@@ -962,82 +795,11 @@
           "from": "is-fullwidth-code-point@1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "from": "is-typedarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "optional": true
-        },
         "isarray": {
           "version": "1.0.0",
           "from": "isarray@1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "from": "isstream@0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "from": "jodid25519@1.0.2",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "optional": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "from": "jsbn@0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "from": "json-schema@0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "from": "json-stable-stringify@1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "optional": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "from": "jsonify@0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "from": "jsprim@1.4.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "from": "mime-db@1.27.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "from": "mime-types@2.1.15",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
         },
         "minimatch": {
           "version": "3.0.4",
@@ -1048,6 +810,17 @@
           "version": "0.0.8",
           "from": "minimist@0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "from": "minipass@2.2.4",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz"
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "from": "minizlib@1.1.0",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -1060,10 +833,16 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "optional": true
         },
+        "needle": {
+          "version": "2.2.0",
+          "from": "needle@2.2.0",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+          "optional": true
+        },
         "node-pre-gyp": {
-          "version": "0.6.39",
-          "from": "node-pre-gyp@^0.6.39",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "version": "0.9.1",
+          "from": "node-pre-gyp@0.9.1",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
           "optional": true
         },
         "nopt": {
@@ -1072,22 +851,28 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "optional": true
         },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "from": "npm-bundled@1.0.3",
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "from": "npm-packlist@1.1.10",
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+          "optional": true
+        },
         "npmlog": {
-          "version": "4.1.0",
-          "from": "npmlog@4.1.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "version": "4.1.2",
+          "from": "npmlog@4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "optional": true
         },
         "number-is-nan": {
           "version": "1.0.1",
           "from": "number-is-nan@1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "from": "oauth-sign@0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1113,43 +898,27 @@
           "optional": true
         },
         "osenv": {
-          "version": "0.1.4",
-          "from": "osenv@0.1.4",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "version": "0.1.5",
+          "from": "osenv@0.1.5",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "optional": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
           "from": "path-is-absolute@1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "from": "performance-now@0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "optional": true
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "from": "process-nextick-args@1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "from": "punycode@1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "from": "qs@6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "version": "2.0.0",
+          "from": "process-nextick-args@2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "optional": true
         },
         "rc": {
-          "version": "1.2.1",
-          "from": "rc@1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "version": "1.2.6",
+          "from": "rc@1.2.6",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
           "optional": true,
           "dependencies": {
             "minimist": {
@@ -1161,30 +930,38 @@
           }
         },
         "readable-stream": {
-          "version": "2.2.9",
-          "from": "readable-stream@2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-        },
-        "request": {
-          "version": "2.81.0",
-          "from": "request@2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "version": "2.3.6",
+          "from": "readable-stream@2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "optional": true
         },
         "rimraf": {
-          "version": "2.6.1",
-          "from": "rimraf@2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+          "version": "2.6.2",
+          "from": "rimraf@2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "optional": true
         },
         "safe-buffer": {
-          "version": "5.0.1",
-          "from": "safe-buffer@5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+          "version": "5.1.1",
+          "from": "safe-buffer@5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "from": "safer-buffer@2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "from": "sax@1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "optional": true
         },
         "semver": {
-          "version": "5.3.0",
-          "from": "semver@5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "version": "5.5.0",
+          "from": "semver@5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "optional": true
         },
         "set-blocking": {
@@ -1199,40 +976,16 @@
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "optional": true
         },
-        "sntp": {
-          "version": "1.0.9",
-          "from": "sntp@1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "from": "sshpk@1.13.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@1.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
-        },
         "string_decoder": {
-          "version": "1.0.1",
-          "from": "string_decoder@1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+          "version": "1.1.1",
+          "from": "string_decoder@1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "from": "string-width@1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "from": "stringstream@0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -1246,55 +999,15 @@
           "optional": true
         },
         "tar": {
-          "version": "2.2.1",
-          "from": "tar@2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "from": "tar-pack@3.4.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-          "optional": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "from": "tough-cookie@2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "optional": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "from": "tunnel-agent@0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "optional": true
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "from": "tweetnacl@0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "from": "uid-number@0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "version": "4.4.1",
+          "from": "tar@4.4.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
           "from": "util-deprecate@1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "from": "uuid@3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "from": "verror@1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "optional": true
         },
         "wide-align": {
@@ -1307,6 +1020,11 @@
           "version": "1.0.2",
           "from": "wrappy@1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "from": "yallist@3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz"
         }
       }
     },
@@ -1361,16 +1079,9 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz"
     },
     "http-errors": {
-      "version": "1.6.2",
+      "version": "1.6.3",
       "from": "http-errors@>=1.6.2 <1.7.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-      "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "from": "depd@1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1539,9 +1250,9 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "lodash": {
-      "version": "4.17.5",
+      "version": "4.17.10",
       "from": "lodash@>=4.17.4 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -1562,6 +1273,11 @@
       "version": "0.3.0",
       "from": "media-typer@0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+    },
+    "memory-cache": {
+      "version": "0.2.0",
+      "from": "memory-cache@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz"
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -1624,9 +1340,9 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz"
     },
     "nan": {
-      "version": "2.9.2",
+      "version": "2.10.0",
       "from": "nan@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz"
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
     },
     "negotiator": {
       "version": "0.6.1",
@@ -1719,9 +1435,9 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-4.13.0.tgz"
     },
     "pino-std-serializers": {
-      "version": "1.0.0",
+      "version": "1.2.0",
       "from": "pino-std-serializers@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-1.2.0.tgz"
     },
     "postinstall-build": {
       "version": "5.0.1",
@@ -1740,7 +1456,7 @@
     },
     "proxy-addr": {
       "version": "2.0.3",
-      "from": "proxy-addr@>=2.0.2 <2.1.0",
+      "from": "proxy-addr@>=2.0.3 <2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz"
     },
     "pump": {
@@ -1805,12 +1521,29 @@
     "raw-body": {
       "version": "2.3.2",
       "from": "raw-body@2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "from": "depd@1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "from": "http-errors@1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz"
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "from": "setprototypeof@1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+        }
+      }
     },
     "readable-stream": {
-      "version": "2.3.5",
+      "version": "2.3.6",
       "from": "readable-stream@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
     },
     "readdir": {
       "version": "0.0.13",
@@ -1843,9 +1576,9 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
     },
     "request": {
-      "version": "2.83.0",
+      "version": "2.85.0",
       "from": "request@>=2.74.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz"
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz"
     },
     "requestretry": {
       "version": "1.13.0",
@@ -1879,18 +1612,18 @@
     },
     "semver": {
       "version": "5.5.0",
-      "from": "semver@>=5.3.0 <6.0.0",
+      "from": "semver@>=5.4.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
     },
     "send": {
-      "version": "0.16.1",
-      "from": "send@0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "version": "0.16.2",
+      "from": "send@0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "dependencies": {
         "statuses": {
-          "version": "1.3.1",
-          "from": "statuses@>=1.3.1 <1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          "version": "1.4.0",
+          "from": "statuses@>=1.4.0 <1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
         }
       }
     },
@@ -1900,9 +1633,9 @@
       "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.5.tgz"
     },
     "serve-static": {
-      "version": "1.13.1",
-      "from": "serve-static@1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz"
+      "version": "1.13.2",
+      "from": "serve-static@1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -1910,13 +1643,13 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "from": "setprototypeof@1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+      "version": "1.1.0",
+      "from": "setprototypeof@1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
     },
     "shimmer": {
       "version": "1.2.0",
-      "from": "shimmer@>=1.1.0 <2.0.0",
+      "from": "shimmer@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz"
     },
     "sntp": {
@@ -1935,9 +1668,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz"
     },
     "sshpk": {
-      "version": "1.13.1",
+      "version": "1.14.1",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz"
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "from": "stack-chain@>=1.3.7 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz"
     },
     "staticify": {
       "version": "2.0.0",
@@ -1945,14 +1683,14 @@
       "resolved": "https://registry.npmjs.org/staticify/-/staticify-2.0.0.tgz"
     },
     "statuses": {
-      "version": "1.4.0",
-      "from": "statuses@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
+      "version": "1.5.0",
+      "from": "statuses@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "from": "string_decoder@>=1.0.3 <1.1.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+      "version": "1.1.1",
+      "from": "string_decoder@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
     },
     "string-width": {
       "version": "1.0.2",
@@ -1970,9 +1708,9 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "supports-color": {
-      "version": "5.3.0",
+      "version": "5.4.0",
       "from": "supports-color@>=5.3.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz"
     },
     "taskgroup": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "4.16.x",
     "i18n": "0.8.x",
     "lodash": "^4.17.4",
+    "memory-cache": "^0.2.0",
     "minimist": "1.2.x",
     "morgan": "1.9.x",
     "nunjucks": "^3.0.1",

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -80,16 +80,16 @@ module.exports = {
     return new PaymentRequest(data)
   },
 
-  validGatewawyAccount: (opts = {}) => {
+  validGatewayAccount: (opts = {}) => {
     const data = {
-      gateway_account_id : opts.gateway_account_id || randomExternalId(),
-      gateway_account_external_id : opts.gateway_account_external_id || randomExternalId(),
-      payment_method : opts.payment_method || 'DIRECT_DEBIT',
-      service_name : opts.service_name || 'GOV.UK Direct Cake service',
-      payment_provider : opts.payment_provider || 'SANDBOX',
-      description : opts.description || 'Gateway account description',
-      type : opts.type || 'TEST',
-      analytics_id : opts.analytics_id || randomExternalId()
+      gateway_account_id: opts.gateway_account_id || randomExternalId(),
+      gateway_account_external_id: opts.gateway_account_external_id || randomExternalId(),
+      payment_method: opts.payment_method || 'DIRECT_DEBIT',
+      service_name: opts.service_name || 'GOV.UK Direct Cake service',
+      payment_provider: opts.payment_provider || 'SANDBOX',
+      description: opts.description || 'Gateway account description',
+      type: opts.type || 'TEST',
+      analytics_id: opts.analytics_id || randomExternalId()
     }
 
     return new GatewayAccount(data)

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -1,6 +1,7 @@
 'use strict'
 const Payer = require('../../common/classes/Payer.class')
 const PaymentRequest = require('../../common/classes/PaymentRequest.class')
+const GatewayAccount = require('../../common/classes/GatewayAccount.class')
 // Create random values if none provided
 const randomExternalId = () => Math.random().toString(36).substring(7)
 const randomNumber = () => Math.round(Math.random() * 10000) + 1
@@ -77,6 +78,20 @@ module.exports = {
       state: opts.state || 'NEW'
     }
     return new PaymentRequest(data)
-  }
+  },
 
+  validGatewawyAccount: (opts = {}) => {
+    const data = {
+      gateway_account_id : opts.gateway_account_id || randomExternalId(),
+      gateway_account_external_id : opts.gateway_account_external_id || randomExternalId(),
+      payment_method : opts.payment_method || 'DIRECT_DEBIT',
+      service_name : opts.service_name || 'GOV.UK Direct Cake service',
+      payment_provider : opts.payment_provider || 'SANDBOX',
+      description : opts.description || 'Gateway account description',
+      type : opts.type || 'TEST',
+      analytics_id : opts.analytics_id || randomExternalId()
+    }
+
+    return new GatewayAccount(data)
+  }
 }


### PR DESCRIPTION
## WHAT
* Use of a middleware called `get-gateway-account` to retrieve the gateway account data of the current payment request. Once the data is loaded from dd-connector it is cached for 15 mins by default for later use. The data is then exposed under `res.locals.gatewayAccount`.
* Updated the template to show the service name that is made available by the middleware.