### PR TITLE
PP-3258 Fix dead links

### DIFF
--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -13,7 +13,8 @@ module.exports = (req, res) => {
     sortCode: confirmationDetails.sortCode.match(/.{2}/g).join(' '),
     returnUrl: paymentRequest.returnUrl,
     description: paymentRequest.description,
-    amount: paymentRequest.amount
+    amount: paymentRequest.amount,
+    paymentAction: 'confirmation'
   }
   res.render('app/confirmation/get', params)
 }

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -77,6 +77,6 @@ describe('confirmation get controller', function () {
   })
 
   it('should display the enter direct debit page with a link to the direct debit guarantee', () => {
-    expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal(`/direct-debit-guarantee/${paymentRequestExternalId}`)
+    expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal(`/direct-debit-guarantee/confirmation/${paymentRequestExternalId}`)
   })
 })

--- a/app/direct-debit-guarantee/anchor.njk
+++ b/app/direct-debit-guarantee/anchor.njk
@@ -1,6 +1,6 @@
 <div class="grid-row">
   <div class="column-two-thirds">
     <img src="/public/images/directdebit.png" class="direct-debit-logo" />
-    <p class="direct-debit-guarantee">Your payments are protected by the <a href="/direct-debit-guarantee/{{paymentRequestExternalId}}">Direct Debit guarantee</a>.</p>
+    <p class="direct-debit-guarantee">Your payments are protected by the <a href="/direct-debit-guarantee/{{ paymentAction }}/{{ paymentRequestExternalId }}">Direct Debit guarantee</a>.</p>
   </div>
 </div>

--- a/app/direct-debit-guarantee/get.controller.js
+++ b/app/direct-debit-guarantee/get.controller.js
@@ -2,8 +2,10 @@
 
 module.exports = (req, res) => {
   const paymentRequestExternalId = req.params.paymentRequestExternalId
+  const paymentAction = req.params.paymentAction
   const params = {
-    paymentRequestExternalId
+    paymentRequestExternalId,
+    paymentAction
   }
   res.render('app/direct-debit-guarantee/get', params)
 }

--- a/app/direct-debit-guarantee/get.controller.tests.js
+++ b/app/direct-debit-guarantee/get.controller.tests.js
@@ -31,13 +31,14 @@ describe('direct debit guarantee controller', () => {
       expect($(`.form-group`).find('a').attr('href')).to.not.exist // eslint-disable-line no-unused-expressions
     })
   })
-  describe('when requesting guarantee with a charge id', () => {
+  describe('when requesting direct debit guarantee from setup page with a charge id', () => {
     const paymentRequestExternalId = 'sdfihsdufh2e'
+    const paymentAction = 'setup'
     let response, $
 
     before(done => {
       supertest(getApp())
-        .get(`/direct-debit-guarantee/${paymentRequestExternalId}`)
+        .get(`/direct-debit-guarantee/${paymentAction}/${paymentRequestExternalId}`)
         .end((err, res) => {
           response = res
           $ = cheerio.load(res.text)
@@ -51,6 +52,30 @@ describe('direct debit guarantee controller', () => {
     it('should display back links to the payment journey', () => {
       expect($(`.back`).find('a').attr('href')).to.equal(`/setup/${paymentRequestExternalId}`)
       expect($(`.form-group`).find('a').attr('href')).to.equal(`/setup/${paymentRequestExternalId}`)
+    })
+  })
+
+  describe('when requesting direct debit guarantee from confirmation page with a charge id', () => {
+    const paymentRequestExternalId = 'sdfihsdufh2e'
+    const paymentAction = 'confirmation'
+    let response, $
+
+    before(done => {
+      supertest(getApp())
+        .get(`/direct-debit-guarantee/${paymentAction}/${paymentRequestExternalId}`)
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text)
+          done(err)
+        })
+    })
+
+    it('should return a 200 status code', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+    it('should display back links to the payment journey', () => {
+      expect($(`.back`).find('a').attr('href')).to.equal(`/confirmation/${paymentRequestExternalId}`)
+      expect($(`.form-group`).find('a').attr('href')).to.equal(`/confirmation/${paymentRequestExternalId}`)
     })
   })
 })

--- a/app/direct-debit-guarantee/get.njk
+++ b/app/direct-debit-guarantee/get.njk
@@ -6,9 +6,9 @@
 
 {% block content %}
   <main id="content" role="main">
-  {% if paymentRequestExternalId %}
+  {% if paymentAction %}
     <div class="back">
-      <a href="/setup/{{paymentRequestExternalId}}" class="link-back">Back to payment</a>
+      <a href="/{{paymentAction}}/{{ paymentRequestExternalId }}" class="link-back">Back to payment</a>
     </div>
   {% endif %}
     <div class="grid-row">
@@ -20,9 +20,9 @@
         <p>If an error is made in the payment of your Direct Debit, by GOV.UK Pay or your bank or building society, you are entitled to a full and immediate refund of the amount paid from your bank or building society.</p>
         <p>If you receive a refund you are not entitled to, you must pay it back when GOV.UK Pay asks you to.</p>
         <p>You can cancel a Direct Debit at any time by simply contacting your bank or building society. Written confirmation may be required. Please also notify GOV.UK Pay.</p>
-      {% if paymentRequestExternalId %}
+      {% if paymentAction %}
         <div class="form-group">
-          <a href="/setup/{{paymentRequestExternalId}}" class="button-link-back"><button class="button">Back to payment</button></a>
+          <a href="/{{paymentAction}}/{{paymentRequestExternalId}}" class="button-link-back"><button class="button">Back to payment</button></a>
         </div>
       {% endif %}
       </div>

--- a/app/direct-debit-guarantee/index.js
+++ b/app/direct-debit-guarantee/index.js
@@ -9,7 +9,7 @@ const getController = require('./get.controller')
 // Initialisation
 const router = express.Router()
 const indexPath = '/direct-debit-guarantee'
-const paymentJourneyPath = '/direct-debit-guarantee/:paymentRequestExternalId'
+const paymentJourneyPath = '/direct-debit-guarantee/:paymentAction/:paymentRequestExternalId'
 const paths = {
   index: indexPath,
   paymentJourney: paymentJourneyPath

--- a/app/setup/get.controller.js
+++ b/app/setup/get.controller.js
@@ -14,7 +14,8 @@ module.exports = (req, res) => {
     paymentRequestExternalId: paymentRequestExternalId,
     description: paymentRequest.description,
     amount: paymentRequest.amount,
-    returnUrl: `/change-payment-method/${paymentRequestExternalId}`
+    returnUrl: `/change-payment-method/${paymentRequestExternalId}`,
+    paymentAction: 'setup'
   }
   const formValues = session.formValues
   if (!_.isEmpty(formValues)) {

--- a/app/setup/get.controller.tests.js
+++ b/app/setup/get.controller.tests.js
@@ -55,7 +55,7 @@ describe('setup get controller', () => {
     })
 
     it('should display the enter direct debit page with a link to the direct debit guarantee', () => {
-      expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal(`/direct-debit-guarantee/${paymentRequestExternalId}`)
+      expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal(`/direct-debit-guarantee/setup/${paymentRequestExternalId}`)
     })
 
     it('should display the enter direct debit page with a link to cancel the payment', () => {


### PR DESCRIPTION
- Make Direct Debit Guarantee return to the page from where it was called
- In story review, it was discovered that when navigating back from `direct-debit-guarantee` page, the user was sent always to `setup` page. That means that when a user will land on `direct-debit-guarantee` from `confirmation` it will be sent to `setup` when goes back. Now, it will be sent back to where it came from, based on `paymentAction` parameter.
