### PR TITLE
PP-3701 Add back link to confirmation page

### DIFF
--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -8,6 +8,7 @@ const expect = chai.expect
 const nock = require('nock')
 
 // Local dependencies
+const setup = require('../setup')
 const config = require('../../common/config')
 const getApp = require('../../server').getApp
 const paymentFixtures = require('../../test/fixtures/payments-fixtures')
@@ -85,6 +86,10 @@ describe('confirmation get controller', function () {
     expect($(`.cancel-link`).attr('href')).to.equal(`/cancel/${paymentRequestExternalId}`)
   })
 
+  it('should display the confirmation page with a back link to the setup page', () => {
+    const url = setup.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
+    expect($('.link-back').attr('href')).to.equal(url)
+  })
   it('should display the enter direct debit page with a link to the direct debit guarantee', () => {
     expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal(`/direct-debit-guarantee/confirmation/${paymentRequestExternalId}`)
   })

--- a/app/confirmation/get.njk
+++ b/app/confirmation/get.njk
@@ -6,6 +6,9 @@
 
 {% block content %}
   <main id="content" role="main">
+   <div>
+      <a href="/setup/{{paymentRequestExternalId}}" class="link-back">Back</a>
+   </div>
     <div class="grid-row relative">
       <div class="column-two-thirds">
         <h1 class="heading-large">Check your details are correct</h1>

--- a/app/setup/get.controller.js
+++ b/app/setup/get.controller.js
@@ -18,7 +18,14 @@ module.exports = (req, res) => {
   }
   const formValues = session.formValues
 
-  if (!_.isEmpty(formValues)) {
+  if (_.isEmpty(formValues) && paymentRequest.payer) {
+    params.formValues = {
+      account_holder_name: paymentRequest.payer.accountHolderName,
+      email: paymentRequest.payer.email,
+      requires_authorisation: paymentRequest.payer.requiresAuthorisation.toString()
+    }
+    params.validationErrors = null
+  } else if (!_.isEmpty(formValues)) {
     // set values to current view
     params.formValues = formValues
     params.validationErrors = session.validationErrors

--- a/common/classes/PaymentRequest.class.js
+++ b/common/classes/PaymentRequest.class.js
@@ -1,4 +1,5 @@
 'use strict'
+const Payer = require('./Payer.class')
 
 class PaymentRequest {
   constructor (opts) {
@@ -8,6 +9,7 @@ class PaymentRequest {
     this.gatewayAccountExternalId = opts.gateway_account_external_id
     this.amount = penceToPounds(opts.amount)
     this.description = opts.description
+    this.payer = opts.payer ? new Payer(opts.payer) : null
     this.type = opts.type
     this.state = opts.state
   }

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -52,7 +52,8 @@ module.exports = {
       description: opts.description || 'buy Silvia a coffee',
       amount: opts.amount || randomNumber(),
       type: opts.type || 'CHARGE',
-      state: opts.state || 'NEW'
+      state: opts.state || 'NEW',
+      payer: opts.payer || null
     }
     return {
       getPlain: () => {
@@ -93,7 +94,8 @@ module.exports = {
       description: opts.description || 'buy Silvia a coffee',
       amount: opts.amount || randomNumber(),
       type: opts.type || 'CHARGE',
-      state: opts.state || 'NEW'
+      state: opts.state || 'NEW',
+      payer: opts.payer || null
     }
     return new PaymentRequest(data)
   },


### PR DESCRIPTION
## WHAT
We are now allowing the user to edit dd details after having reached the confirmation page. We can reinstate the link to go back to the enter dd details page.

Going back via link will not pre-populate the form for now, until connector is merged.
