### PR TITLE
PP-3701 Pass confirmation details to connector

### DIFF
--- a/app/confirmation/post.controller.js
+++ b/app/confirmation/post.controller.js
@@ -2,11 +2,15 @@
 
 const {renderErrorView} = require('../../common/response')
 const connectorClient = require('../../common/clients/connector-client')
+const {getSessionVariable} = require('../../common/config/cookies')
 
 module.exports = (req, res) => {
   const paymentRequest = res.locals.paymentRequest
-
-  connectorClient.payment.confirmDirectDebitDetails(paymentRequest.gatewayAccountExternalId, paymentRequest.externalId, req.correlationId)
+  const session = getSessionVariable(req, paymentRequest.externalId)
+  connectorClient.payment.confirmDirectDebitDetails(paymentRequest.gatewayAccountExternalId, paymentRequest.externalId, {
+    account_number: session.confirmationDetails.accountNumber,
+    sort_code: session.confirmationDetails.sortCode.match(/.{2}/g).join('')
+  }, req.correlationId)
     .then(() => {
       return res.redirect(303, paymentRequest.returnUrl)
     })

--- a/app/confirmation/post.controller.tests.js
+++ b/app/confirmation/post.controller.tests.js
@@ -27,11 +27,19 @@ const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
 describe('confirmation POST controller', () => {
   const csrfSecret = '123'
   const csrfToken = csrf().create(csrfSecret)
+  const sortCode = '123456'
+  const accountNumber = '12345678'
+  const payer = paymentFixtures.validPayer({
+    account_holder_name: 'payer',
+    sort_code: sortCode,
+    account_number: accountNumber
+  })
   const cookieHeader = new CookieBuilder(
     gatewayAccoutExternalId,
     paymentRequestExternalId
   )
     .withCsrfSecret(csrfSecret)
+    .withConfirmationDetails(payer)
     .build()
   afterEach(() => {
     nock.cleanAll()
@@ -43,7 +51,10 @@ describe('confirmation POST controller', () => {
         .get(`/v1/accounts/${gatewayAccoutExternalId}/payment-requests/${paymentRequestExternalId}`)
         .reply(200, paymentResponse)
       nock(config.CONNECTOR_URL)
-        .post(`/v1/api/accounts/${gatewayAccoutExternalId}/payment-requests/${paymentRequestExternalId}/confirm`)
+        .post(`/v1/api/accounts/${gatewayAccoutExternalId}/payment-requests/${paymentRequestExternalId}/confirm`, {
+          sort_code: sortCode,
+          account_number: accountNumber
+        })
         .reply(201)
       nock(config.CONNECTOR_URL).get(`/v1/api/accounts/${gatewayAccoutExternalId}`)
         .reply(200, gatewayAccountResponse)
@@ -73,7 +84,10 @@ describe('confirmation POST controller', () => {
         .get(`/v1/accounts/${gatewayAccoutExternalId}/payment-requests/${paymentRequestExternalId}`)
         .reply(200, paymentResponse)
       nock(config.CONNECTOR_URL)
-        .get(`/v1/api/accounts/${gatewayAccoutExternalId}/payment-requests/${paymentRequestExternalId}/confirm`)
+        .get(`/v1/api/accounts/${gatewayAccoutExternalId}/payment-requests/${paymentRequestExternalId}/confirm`, {
+          sort_code: sortCode,
+          account_number: accountNumber
+        })
         .reply(409)
       nock(config.CONNECTOR_URL)
         .get(`/v1/api/accounts/${gatewayAccoutExternalId}`)

--- a/common/clients/connector-client.js
+++ b/common/clients/connector-client.js
@@ -86,13 +86,14 @@ function submitDirectDebitDetails (accountId, paymentRequestExternalId, body, co
   })
 }
 
-function confirmDirectDebitDetails (accountId, paymentRequestExternalId, correlationId) {
+function confirmDirectDebitDetails (accountId, paymentRequestExternalId, body, correlationId) {
   return baseClient.post({
     headers,
     baseUrl,
     json: true,
     url: `/api/accounts/${accountId}/payment-requests/${paymentRequestExternalId}/confirm`,
     service: service,
+    body: body,
     correlationId: correlationId,
     description: `confirm a payment`
   })


### PR DESCRIPTION
## WHAT
 - We are hashing account number and sort code in connector. This means
   we don't have those details when the user confirms their details, unless
   frontend passes them back to connector