### PR TITLE
PP-3701 Frontend uses PUT to create/update a payer

### DIFF
--- a/app/setup/post.controller.tests.js
+++ b/app/setup/post.controller.tests.js
@@ -79,7 +79,7 @@ describe('setup post controller', () => {
         .get(`/v1/api/accounts/${gatewayAccoutExternalId}`)
         .reply(200, gatewayAccountResponse)
       nock(config.CONNECTOR_URL)
-        .post(`/v1/api/accounts/${gatewayAccoutExternalId}/payment-requests/${paymentRequestExternalId}/payers`, {
+        .put(`/v1/api/accounts/${gatewayAccoutExternalId}/payment-requests/${paymentRequestExternalId}/payers`, {
           account_holder_name: formValues.accountHolderName,
           sort_code: normalise.sortCode(formValues.sortCode),
           account_number: normalise.accountNumber(formValues.accountNumber),

--- a/common/clients/connector-client.js
+++ b/common/clients/connector-client.js
@@ -72,7 +72,7 @@ function deleteToken (token, correlationId) {
 }
 
 function submitDirectDebitDetails (accountId, paymentRequestExternalId, body, correlationId) {
-  return baseClient.post({
+  return baseClient.put({
     headers,
     baseUrl,
     json: true,


### PR DESCRIPTION
## WHAT
We now create or update a payer, hence we should use a `PUT` and not a `POST` to do so.
