### PR TITLE
PP-3700 Fix navigation to page confirmation

### DIFF
--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -1,19 +1,23 @@
 'use strict'
 const {getSessionVariable} = require('../../common/config/cookies')
+const {renderErrorView} = require('../../common/response')
 
 module.exports = (req, res) => {
   const paymentRequest = res.locals.paymentRequest
   const session = getSessionVariable(req, paymentRequest.externalId)
-
-  const params = {
-    paymentRequestExternalId: paymentRequest.externalId,
-    accountHolderName: session.confirmationDetails.accountHolderName,
-    accountNumber: session.confirmationDetails.accountNumber,
-    sortCode: session.confirmationDetails.sortCode.match(/.{2}/g).join(' '),
-    returnUrl: paymentRequest.returnUrl,
-    description: paymentRequest.description,
-    amount: paymentRequest.amount,
-    paymentAction: 'confirmation'
+  if (session.confirmationDetails) {
+    const params = {
+      paymentRequestExternalId: paymentRequest.externalId,
+      accountHolderName: session.confirmationDetails.accountHolderName,
+      accountNumber: session.confirmationDetails.accountNumber,
+      sortCode: session.confirmationDetails.sortCode.match(/.{2}/g).join(' '),
+      returnUrl: paymentRequest.returnUrl,
+      description: paymentRequest.description,
+      amount: paymentRequest.amount,
+      paymentAction: 'confirmation'
+    }
+    res.render('app/confirmation/get', params)
+  } else {
+    renderErrorView(req, res, 'No money has been taken from your account, please try again later.', 500)
   }
-  res.render('app/confirmation/get', params)
 }


### PR DESCRIPTION
- When navigating from setup directly to confirmation page,  without
adding any details we should show the error page, instead of a 500 and
an exception dump

