### PR TITLE
PP-3714 Call connector to validate bank account details

### DIFF
--- a/app/setup/post.controller.js
+++ b/app/setup/post.controller.js
@@ -37,23 +37,46 @@ module.exports = (req, res) => {
   // Validation
   const payer = new Payer(normalisedFormValues)
   const payerValidatorErrors = payerValidator(payer)
+  const redirectWithValidationErrors = prepareValidationErrors(res, req, paymentRequestExternalId, formValues)
   if (lodash.isEmpty(payerValidatorErrors)) {
-    // Process request
-    connectorClient.payment.submitDirectDebitDetails(gatewayAccountExternalId, paymentRequestExternalId, normalisedFormValues, req.correlationId)
-      .then(payerExternalId => {
-        logger.info(`[${req.correlationId}] Submitted payment details for request: ${paymentRequestExternalId}, payer: ${payerExternalId}`)
-        req.body.payer_external_id = payerExternalId
-        setSessionVariable(req, `${paymentRequestExternalId}.confirmationDetails`, payer)
-        const url = confirmation.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
-        return res.redirect(303, url)
-      })
-      .catch(() => {
-        renderErrorView(req, res, 'No money has been taken from your account, please try again later.')
+    connectorClient.payment.validateBankAccountDetails(gatewayAccountExternalId, paymentRequestExternalId, {
+      account_number: normalisedFormValues.account_number,
+      sort_code: normalisedFormValues.sort_code
+    }, req.correlationId)
+      .then(bankAccount => {
+        if (bankAccount.is_valid) {
+          normalisedFormValues.bank_name = bankAccount.bank_name
+          connectorClient.payment.submitDirectDebitDetails(gatewayAccountExternalId, paymentRequestExternalId, normalisedFormValues, req.correlationId)
+            .then(payerExternalId => {
+              logger.info(`[${req.correlationId}] Submitted payment details for request: ${paymentRequestExternalId}, payer: ${payerExternalId}`)
+              req.body.payer_external_id = payerExternalId
+              setSessionVariable(req, `${paymentRequestExternalId}.confirmationDetails`, payer)
+              const url = confirmation.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
+              return res.redirect(303, url)
+            })
+            .catch(() => {
+              renderErrorView(req, res, 'No money has been taken from your account, please try again later.')
+            })
+        } else {
+          redirectWithValidationErrors([
+            {
+              id: 'sort-code',
+              label: 'Sort code'
+            },
+            {
+              id: 'account-number',
+              label: 'Account number'
+            }
+          ])
+        }
       })
   } else {
-    setSessionVariable(req, `${paymentRequestExternalId}.formValues`, formValues)
-    setSessionVariable(req, `${paymentRequestExternalId}.validationErrors`, payerValidatorErrors)
-    const url = '/setup/:paymentRequestExternalId'.replace(':paymentRequestExternalId', paymentRequestExternalId)
-    return res.redirect(303, url)
+    redirectWithValidationErrors(payerValidatorErrors)
   }
+}
+const prepareValidationErrors = (res, req, paymentRequestExternalId, formValues) => (validationErrors) => {
+  setSessionVariable(req, `${paymentRequestExternalId}.formValues`, formValues)
+  setSessionVariable(req, `${paymentRequestExternalId}.validationErrors`, validationErrors)
+  const url = '/setup/:paymentRequestExternalId'.replace(':paymentRequestExternalId', paymentRequestExternalId)
+  return res.redirect(303, url)
 }

--- a/common/clients/connector-client.js
+++ b/common/clients/connector-client.js
@@ -23,7 +23,8 @@ module.exports = {
     submitDirectDebitDetails: submitDirectDebitDetails,
     confirmDirectDebitDetails: confirmDirectDebitDetails,
     cancelPaymentRequest: cancelPaymentRequest,
-    changePaymentMethod: changePaymentMethod
+    changePaymentMethod: changePaymentMethod,
+    validateBankAccountDetails: validateBankAccountDetails
   }
 }
 
@@ -98,6 +99,20 @@ function confirmDirectDebitDetails (accountId, paymentRequestExternalId, body, c
     description: `confirm a payment`
   })
 }
+
+function validateBankAccountDetails (accountId, paymentRequestExternalId, body, correlationId) {
+  return baseClient.post({
+    headers,
+    baseUrl,
+    json: true,
+    url: `/api/accounts/${accountId}/payment-requests/${paymentRequestExternalId}/payers/bank-account/validate`,
+    service: service,
+    body: body,
+    correlationId: correlationId,
+    description: `validate bank account details`
+  })
+}
+
 function cancelPaymentRequest (accountId, paymentRequestExternalId, correlationId) {
   return baseClient.post({
     headers,


### PR DESCRIPTION
## WHAT
 - We are introducing a new endpoint in connector which validates bank account details.
   For sandbox, those will always be valid. For gocardless, we are going to call them and they
   will return the result of the modulus checking algorithm, together with additional info
   like bank name, which _could_ be used in the future for on-blur validation
 - We submit details only if our "local" validation and online validation actually pass
 - If connector returns that the details are invalid, we display an error
