### PR TITLE
PP-3700 Fix navigation to page confirmation

### DIFF
--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -1,11 +1,14 @@
 'use strict'
 const {getSessionVariable} = require('../../common/config/cookies')
-const {renderErrorView} = require('../../common/response')
+const {renderErrorView, renderPaymentCompletedSummary} = require('../../common/response')
 
 module.exports = (req, res) => {
   const paymentRequest = res.locals.paymentRequest
   const session = getSessionVariable(req, paymentRequest.externalId)
-  if (session.confirmationDetails) {
+  if (paymentRequest.state.status === 'pending') {
+    renderPaymentCompletedSummary(req, res, {'status': 'successful', 'returnUrl': paymentRequest.returnUrl}
+    )
+  } else if (session.confirmationDetails) {
     const params = {
       paymentRequestExternalId: paymentRequest.externalId,
       accountHolderName: session.confirmationDetails.accountHolderName,

--- a/common/response.js
+++ b/common/response.js
@@ -15,7 +15,14 @@ function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
   res.render('common/templates/error', {'message': msg})
 }
 
+function renderPaymentCompletedSummary (req, res, params) {
+  res.setHeader('Content-Type', 'text/html')
+  res.status(200)
+  res.render('common/templates/payment_completed_summary', params)
+}
+
 module.exports = {
   response: response,
-  renderErrorView: errorResponse
+  renderErrorView: errorResponse,
+  renderPaymentCompletedSummary: renderPaymentCompletedSummary
 }

--- a/common/templates/payment_completed_summary.njk
+++ b/common/templates/payment_completed_summary.njk
@@ -1,0 +1,16 @@
+{% extends "common/templates/layout.njk" %}
+
+{% block page_title %}
+  Your payment was {{ status }} - GOV.UK Pay
+{% endblock %}
+
+{% block content %}
+  <main id="content" class="content-wrapper error-pages grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large {{ status }}"> Your payment was {{ status }} </h1>
+      <p class="lede">To make any changes to your payment you’ll need to contact the service.</p>
+
+      <a href="{{ returnUrl }}" id="return-url" class="lede"> View your payment summary </a>
+    </div>
+  </main>
+{% endblock %}


### PR DESCRIPTION
- When navigating to confirmation page, after a successful payment, the
user should be presented with a message that the payment was successful
and directed to the service page to follow the status of that page
- This behaviour keeps it similar with card payments
