### PR TITLE
PP-3714 Add hint text and dynamic error messages for field validation 

### DIFF
--- a/app/setup/get.njk
+++ b/app/setup/get.njk
@@ -36,9 +36,10 @@
             name='sort-code',
             label='Sort code',
             value=formValues.sort_code,
+            hintText='Must be 6 digits long',
             extraClasses='form-control-1-3',
             attributes={'data-validate': 'sort-code'},
-            errorLabel='Sort code must contain 6 digits',
+            errorLabel='Either your sort code or account number is not right',
             isError=errors['sort-code']
           )}}
 
@@ -46,9 +47,10 @@
             name='account-number',
             label='Account number',
             value=formValues.account_number,
+            hintText='Must be between 8 and 10 digits long',
             extraClasses='form-control-1-3',
             attributes={'data-validate': 'account-number'},
-            errorLabel='Account number must contain 6-8 digits',
+            errorLabel='Either your sort code or account number is not right',
             isError=errors['account-number']
           )}}
 

--- a/app/setup/post.controller.js
+++ b/app/setup/post.controller.js
@@ -44,20 +44,20 @@ module.exports = (req, res) => {
       sort_code: normalisedFormValues.sort_code
     }, req.correlationId)
       .then(bankAccount => {
-        // if (bankAccount.is_valid) {
-        //   normalisedFormValues.bank_name = bankAccount.bank_name
-        //   connectorClient.payment.submitDirectDebitDetails(gatewayAccountExternalId, paymentRequestExternalId, normalisedFormValues, req.correlationId)
-        //     .then(payerExternalId => {
-        //       logger.info(`[${req.correlationId}] Submitted payment details for request: ${paymentRequestExternalId}, payer: ${payerExternalId}`)
-        //       req.body.payer_external_id = payerExternalId
-        //       setSessionVariable(req, `${paymentRequestExternalId}.confirmationDetails`, payer)
-        //       const url = confirmation.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
-        //       return res.redirect(303, url)
-        //     })
-        //     .catch(() => {
-        //       renderErrorView(req, res, 'No money has been taken from your account, please try again later.')
-        //     })
-        // } else {
+        if (bankAccount.is_valid) {
+          normalisedFormValues.bank_name = bankAccount.bank_name
+          connectorClient.payment.submitDirectDebitDetails(gatewayAccountExternalId, paymentRequestExternalId, normalisedFormValues, req.correlationId)
+            .then(payerExternalId => {
+              logger.info(`[${req.correlationId}] Submitted payment details for request: ${paymentRequestExternalId}, payer: ${payerExternalId}`)
+              req.body.payer_external_id = payerExternalId
+              setSessionVariable(req, `${paymentRequestExternalId}.confirmationDetails`, payer)
+              const url = confirmation.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
+              return res.redirect(303, url)
+            })
+            .catch(() => {
+              renderErrorView(req, res, 'No money has been taken from your account, please try again later.')
+            })
+        } else {
           redirectWithValidationErrors([
             {
               id: 'sort-code',
@@ -68,7 +68,7 @@ module.exports = (req, res) => {
               label: 'Account number'
             }
           ])
-        // }
+        }
       })
   } else {
     redirectWithValidationErrors(payerValidatorErrors)

--- a/app/setup/post.controller.js
+++ b/app/setup/post.controller.js
@@ -44,20 +44,20 @@ module.exports = (req, res) => {
       sort_code: normalisedFormValues.sort_code
     }, req.correlationId)
       .then(bankAccount => {
-        if (bankAccount.is_valid) {
-          normalisedFormValues.bank_name = bankAccount.bank_name
-          connectorClient.payment.submitDirectDebitDetails(gatewayAccountExternalId, paymentRequestExternalId, normalisedFormValues, req.correlationId)
-            .then(payerExternalId => {
-              logger.info(`[${req.correlationId}] Submitted payment details for request: ${paymentRequestExternalId}, payer: ${payerExternalId}`)
-              req.body.payer_external_id = payerExternalId
-              setSessionVariable(req, `${paymentRequestExternalId}.confirmationDetails`, payer)
-              const url = confirmation.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
-              return res.redirect(303, url)
-            })
-            .catch(() => {
-              renderErrorView(req, res, 'No money has been taken from your account, please try again later.')
-            })
-        } else {
+        // if (bankAccount.is_valid) {
+        //   normalisedFormValues.bank_name = bankAccount.bank_name
+        //   connectorClient.payment.submitDirectDebitDetails(gatewayAccountExternalId, paymentRequestExternalId, normalisedFormValues, req.correlationId)
+        //     .then(payerExternalId => {
+        //       logger.info(`[${req.correlationId}] Submitted payment details for request: ${paymentRequestExternalId}, payer: ${payerExternalId}`)
+        //       req.body.payer_external_id = payerExternalId
+        //       setSessionVariable(req, `${paymentRequestExternalId}.confirmationDetails`, payer)
+        //       const url = confirmation.paths.index.replace(':paymentRequestExternalId', paymentRequestExternalId)
+        //       return res.redirect(303, url)
+        //     })
+        //     .catch(() => {
+        //       renderErrorView(req, res, 'No money has been taken from your account, please try again later.')
+        //     })
+        // } else {
           redirectWithValidationErrors([
             {
               id: 'sort-code',
@@ -68,7 +68,7 @@ module.exports = (req, res) => {
               label: 'Account number'
             }
           ])
-        }
+        // }
       })
   } else {
     redirectWithValidationErrors(payerValidatorErrors)

--- a/app/setup/post.controller.tests.js
+++ b/app/setup/post.controller.tests.js
@@ -420,6 +420,14 @@ describe('setup post controller', () => {
       expect(errorField.find('a[href="#account-number"]').length).to.equal(1)
     })
 
+    it('should contain an inline error for sort code', () => {
+      expect($('label[for=sort-code]').attr('data-error-label')).to.equal('Either your sort code or account number is not right')
+    })
+
+    it('should contain an inline error for account number', () => {
+      expect($('label[for=account-number]').attr('data-error-label')).to.equal('Either your sort code or account number is not right')
+    })
+
     it('should contain email pre-filled after redirect', () => {
       expect($('#email').val()).to.equal(formValues.email)
     })

--- a/common/browsered/field-validation-checks.js
+++ b/common/browsered/field-validation-checks.js
@@ -5,16 +5,46 @@ const emailValidator = require('../utils/email-validator')
 // Constants
 const NUMBERS_ONLY = new RegExp('^[0-9]+$')
 
+const errorMessages = {
+  required: 'This field cannot be blank',
+  validEmail: 'Please use a valid email address',
+  checked: 'Please choose an option',
+  sortCode: 'Sort code must contain 6 digits',
+  accountNumber: 'Account number must contain 6-8 digits'
+}
+
 // Exports
-exports.isEmpty = value => value.trim() === ''
+exports.isNotEmpty = value => {
+  return {
+    valid: value.trim() !== '',
+    message: errorMessages.required
+  }
+}
 
-exports.isChecked = field => field && (field.checked === true)
+exports.isChecked = field => {
+  return {
+    valid: field && (field.checked === true)
+  }
+}
 
-exports.isValidEmail = value => emailValidator(value)
+exports.isValidEmail = value => {
+  return {
+    valid: emailValidator(value),
+    message: errorMessages.validEmail
+  }
+}
 
-exports.isSortCode = value => /^[ -]*(?:[0-9][ -]*){6}$/.test(value)
+exports.isSortCode = value => {
+  return {
+    valid: /^[ -]*(?:[0-9][ -]*){6}$/.test(value),
+    message: errorMessages.sortCode
+  }
+}
 
 exports.isAccountNumber = value => {
   const trimmedAccountNumber = value.replace(/\s/g, '')
-  return NUMBERS_ONLY.test(trimmedAccountNumber) && (trimmedAccountNumber.length >= 6 && trimmedAccountNumber.length <= 8)
+  return {
+    valid: NUMBERS_ONLY.test(trimmedAccountNumber) && (trimmedAccountNumber.length >= 6 && trimmedAccountNumber.length <= 8),
+    message: errorMessages.accountNumber
+  }
 }

--- a/common/browsered/field-validation-checks.js
+++ b/common/browsered/field-validation-checks.js
@@ -9,8 +9,8 @@ const errorMessages = {
   required: 'This field cannot be blank',
   validEmail: 'Please use a valid email address',
   checked: 'Please choose an option',
-  sortCode: 'Sort code must contain 6 digits',
-  accountNumber: 'Account number must contain 6-8 digits'
+  sortCode: 'Enter a real sort code with 6 digits',
+  accountNumber: 'Enter a real account number between 8 and 10 digits long'
 }
 
 // Exports

--- a/common/browsered/field-validation-checks.test.js
+++ b/common/browsered/field-validation-checks.test.js
@@ -4,71 +4,93 @@
 const {expect} = require('chai')
 
 // Local dependencies
-const {isSortCode, isAccountNumber, isChecked} = require('./field-validation-checks')
+const {isSortCode, isAccountNumber, isChecked, isNotEmpty, isValidEmail} = require('./field-validation-checks')
 
 describe('field validation checks', () => {
   describe('isSortCode', () => {
-    it('should return false if it is a invalid sort code', () => {
-      expect(isSortCode('12345')).to.equal(false)
-      expect(isSortCode('1234567')).to.equal(false)
-      expect(isSortCode('0234567')).to.equal(false)
-      expect(isSortCode('-12345')).to.equal(false)
-      expect(isSortCode('12345-')).to.equal(false)
-      expect(isSortCode('12-3-45')).to.equal(false)
-      expect(isSortCode('12-34-567')).to.equal(false)
-      expect(isSortCode('12-3a-56')).to.equal(false)
-      expect(isSortCode(' 12345')).to.equal(false)
-      expect(isSortCode('12345 ')).to.equal(false)
-      expect(isSortCode('12 3 45')).to.equal(false)
-      expect(isSortCode('12 34 567')).to.equal(false)
-      expect(isSortCode('12 3a 56')).to.equal(false)
-      expect(isSortCode('123$@456')).to.equal(false)
+    it('should be valid for a valid sort code', () => {
+      expect(isSortCode('12-34-56').valid).to.equal(true)
+      expect(isSortCode('12 34 56').valid).to.equal(true)
+      expect(isSortCode('123456').valid).to.equal(true)
+      expect(isSortCode('01-23-45').valid).to.equal(true)
+      expect(isSortCode('01 23 45').valid).to.equal(true)
+      expect(isSortCode('----0-1-2-3-4-5----').valid).to.equal(true)
+      expect(isSortCode('    0  1 2   3 4 5   ').valid).to.equal(true)
+      expect(isSortCode('-123456-').valid).to.equal(true)
+      expect(isSortCode(' 123456 ').valid).to.equal(true)
     })
 
-    it('should return true if it is a valid sort code', () => {
-      expect(isSortCode('12-34-56')).to.equal(true)
-      expect(isSortCode('12 34 56')).to.equal(true)
-      expect(isSortCode('123456')).to.equal(true)
-      expect(isSortCode('01-23-45')).to.equal(true)
-      expect(isSortCode('01 23 45')).to.equal(true)
-      expect(isSortCode('----0-1-2-3-4-5----')).to.equal(true)
-      expect(isSortCode('    0  1 2   3 4 5   ')).to.equal(true)
-      expect(isSortCode('-123456-')).to.equal(true)
-      expect(isSortCode(' 123456 ')).to.equal(true)
+    it('should not be valid for an invalid sort code', () => {
+      expect(isSortCode('12345').valid).to.equal(false)
+      expect(isSortCode('1234567').valid).to.equal(false)
+      expect(isSortCode('0234567').valid).to.equal(false)
+      expect(isSortCode('-12345').valid).to.equal(false)
+      expect(isSortCode('12345-').valid).to.equal(false)
+      expect(isSortCode('12-3-45').valid).to.equal(false)
+      expect(isSortCode('12-34-567').valid).to.equal(false)
+      expect(isSortCode('12-3a-56').valid).to.equal(false)
+      expect(isSortCode(' 12345').valid).to.equal(false)
+      expect(isSortCode('12345 ').valid).to.equal(false)
+      expect(isSortCode('12 3 45').valid).to.equal(false)
+      expect(isSortCode('12 34 567').valid).to.equal(false)
+      expect(isSortCode('12 3a 56').valid).to.equal(false)
+      expect(isSortCode('123$@456').valid).to.equal(false)
+    })
+    it('should display an error message for an invalid sort code', () => {
+      expect(isSortCode('invalid').message).to.equal('Enter a real sort code with 6 digits')
     })
   })
-})
-
-describe('field validation checks', () => {
+  describe('isNotEmpty', () => {
+    it('should be valid for a non empty string', () => {
+      expect(isNotEmpty('some').valid).to.equal(true)
+    })
+    it('should not be valid for an empty string', () => {
+      expect(isNotEmpty('').valid).to.equal(false)
+    })
+    it('should display an error message for an empty string', () => {
+      expect(isNotEmpty('invalid').message).to.equal('This field cannot be blank')
+    })
+  })
+  describe('isValidEmail', () => {
+    it('should be valid for an email', () => {
+      expect(isValidEmail('thisisan@email.test').valid).to.equal(true)
+    })
+    it('should not be valid for an invalid email', () => {
+      expect(isValidEmail('thisisnot@email').valid).to.equal(false)
+    })
+    it('should display an error message for an invalid email', () => {
+      expect(isValidEmail('invalid').message).to.equal('Please use a valid email address')
+    })
+  })
   describe('isAccountNumber', () => {
-    it('should return false if it is a invalid account number', () => {
-      expect(isAccountNumber('123-456')).to.equal(false)
-      expect(isAccountNumber('1-2-3-4-5-6')).to.equal(false)
-      expect(isAccountNumber('12-34-56')).to.equal(false)
-      expect(isAccountNumber('12345')).to.equal(false)
-      expect(isAccountNumber('123456789')).to.equal(false)
-      expect(isAccountNumber('1234a56789')).to.equal(false)
+    it('should be valid for a valid account number', () => {
+      expect(isAccountNumber('123 456').valid).to.equal(true)
+      expect(isAccountNumber(' 1 2 3 4 5 6 ').valid).to.equal(true)
+      expect(isAccountNumber('12 34 56 78').valid).to.equal(true)
+      expect(isAccountNumber('12345678').valid).to.equal(true)
+      expect(isAccountNumber('01234567').valid).to.equal(true)
+      expect(isAccountNumber(' 12345678 ').valid).to.equal(true)
     })
 
-    it('should return true if it is a valid account number', () => {
-      expect(isAccountNumber('123 456')).to.equal(true)
-      expect(isAccountNumber(' 1 2 3 4 5 6 ')).to.equal(true)
-      expect(isAccountNumber('12 34 56 78')).to.equal(true)
-      expect(isAccountNumber('12345678')).to.equal(true)
-      expect(isAccountNumber('01234567')).to.equal(true)
-      expect(isAccountNumber(' 12345678 ')).to.equal(true)
+    it('should not be valid for an invalid account number', () => {
+      expect(isAccountNumber('123-456').valid).to.equal(false)
+      expect(isAccountNumber('1-2-3-4-5-6').valid).to.equal(false)
+      expect(isAccountNumber('12-34-56').valid).to.equal(false)
+      expect(isAccountNumber('12345').valid).to.equal(false)
+      expect(isAccountNumber('123456789').valid).to.equal(false)
+      expect(isAccountNumber('1234a56789').valid).to.equal(false)
+    })
+    it('should display an error message for an invalid account number', () => {
+      expect(isAccountNumber('invalid').message).to.equal('Enter a real account number between 8 and 10 digits long')
     })
   })
-})
-
-describe('field validation checks', () => {
   describe('isChecked', () => {
-    it('should return false if the field is not checked', () => {
-      expect(isChecked({checked: false})).to.equal(false)
+    it('should be valid if the field is checked', () => {
+      expect(isChecked({checked: true}).valid).to.equal(true)
     })
 
-    it('should return true if the field is checked', () => {
-      expect(isChecked({checked: true})).to.equal(true)
+    it('should not be valid if the field is not checked', () => {
+      expect(isChecked({checked: false}).valid).to.equal(false)
     })
   })
 })

--- a/common/browsered/field-validation.js
+++ b/common/browsered/field-validation.js
@@ -27,7 +27,7 @@ function initValidation (e) {
   let validatedFields = findFields(form)
     .map(field => validateField(form, field))
 
-  if (every(validatedFields)) {
+  if (every(validatedFields, 'valid')) {
     form.submit()
   } else {
     populateErrorSummary(form)
@@ -53,36 +53,36 @@ function findFields (form) {
 }
 
 function validateField (form, field) {
-  let isValid = true
+  let result = {}
   let validationTypes = field.getAttribute('data-validate').split(' ')
 
   validationTypes.forEach(validationType => {
     switch (validationType) {
       case 'sort-code' :
-        isValid = checks.isSortCode(field.value)
+        result = checks.isSortCode(field.value)
         break
       case 'account-number' :
-        isValid = checks.isAccountNumber(field.value)
+        result = checks.isAccountNumber(field.value)
         break
       case 'email' :
-        isValid = checks.isValidEmail(field.value)
+        result = checks.isValidEmail(field.value)
         break
       case 'is-checked' :
-        isValid = checks.isChecked(field)
+        result = checks.isChecked(field)
         break
       default :
-        isValid = !checks.isEmpty(field.value)
+        result = checks.isNotEmpty(field.value)
         break
     }
-    if (!isValid) {
-      applyErrorMessaging(form, field)
+    if (!result.valid) {
+      applyErrorMessaging(form, field, result)
     }
   })
 
-  return isValid
+  return result
 }
 
-function applyErrorMessaging (form, field) {
+function applyErrorMessaging (form, field, result) {
   // Modify the field
   if (!field.classList.contains('form-control-error')) {
     field.classList.add('form-control-error')
@@ -94,7 +94,7 @@ function applyErrorMessaging (form, field) {
     const errorLegendElement = formGroup.querySelector('legend')
     if (errorLegendElement === null) {
       const errorElement = document.querySelector('label[for="' + field.name + '"]')
-      const errorLabel = errorElement.getAttribute('data-error-label')
+      const errorLabel = result.message || errorElement.getAttribute('data-error-label')
       errorElement.appendChild(generateErrorMessageElement(errorLabel))
     } else {
       errorLegendElement.appendChild(generateErrorMessageElement(errorLegendElement.getAttribute('data-error-label')))

--- a/common/utils/payer-validator/index.js
+++ b/common/utils/payer-validator/index.js
@@ -6,21 +6,21 @@ const fieldValidationChecks = require('../../browsered/field-validation-checks')
 module.exports = (payer) => {
   const errors = []
 
-  if (fieldValidationChecks.isEmpty(payer.accountHolderName) === true) {
+  if (!fieldValidationChecks.isNotEmpty(payer.accountHolderName).valid) {
     errors.push({
       id: 'account-holder-name',
       label: 'Name on the account'
     })
   }
 
-  if (fieldValidationChecks.isSortCode(payer.sortCode) === false) {
+  if (!fieldValidationChecks.isSortCode(payer.sortCode).valid) {
     errors.push({
       id: 'sort-code',
       label: 'Sort code'
     })
   }
 
-  if (fieldValidationChecks.isAccountNumber(payer.accountNumber) === false) {
+  if (!fieldValidationChecks.isAccountNumber(payer.accountNumber).valid) {
     errors.push({
       id: 'account-number',
       label: 'Account number'
@@ -34,7 +34,7 @@ module.exports = (payer) => {
     })
   }
 
-  if (fieldValidationChecks.isValidEmail(payer.email) === false) {
+  if (!fieldValidationChecks.isValidEmail(payer.email).valid) {
     errors.push({
       id: 'email',
       label: 'Email address'


### PR DESCRIPTION
## WHAT
- Client side field validation on DD didn't allow for custom error messages on from the validator function, this means that if you're validating a field against more than one validator you can only show one error message, this is sad. So now the validator passes back a message which is used as the error message, if it’s not present it defaults to the data attribute error message that is set.
- We were previously hardcoding the error message in the template. As we now can have multiple reasons a single input field might be invalid, we need to be able to specify the error message dynamically.
- Added hint text + slight change of copy in error messages related to sort code and account number
 - We should really share the validation in js commons between our microservices (shameless 🔌) 

with @jonheslop 