### PR TITLE
PP-3838 Mandate state enforcer

### DIFF
--- a/app/cancel/get.controller.tests.js
+++ b/app/cancel/get.controller.tests.js
@@ -20,7 +20,10 @@ const returnUrl = '/change-payment-method'
 const mandateResponse = paymentFixtures.validOneOffMandateResponse({
   external_id: mandateExternalId,
   gateway_account_external_id: gatewayAccoutExternalId,
-  return_url: returnUrl
+  return_url: returnUrl,
+  state: {
+    status: 'started'
+  }
 }).getPlain()
 const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
   gateway_account_external_id: gatewayAccoutExternalId

--- a/app/cancel/index.js
+++ b/app/cancel/index.js
@@ -7,9 +7,10 @@ const express = require('express')
 const getController = require('./get.controller')
 const {validateAndRefreshCsrf} = require('../../common/middleware/csrf/csrf')
 const checkSecureCookie = require('../../common/middleware/check-secure-cookie/check-secure-cookie').middleware
-const getPaymentRequest = require('../../common/middleware/get-mandate/get-mandate').middleware
 const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
 const getService = require('../../common/middleware/get-service/get-service').middleware
+const getMandate = require('../../common/middleware/get-mandate/get-mandate').middleware
+const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middlewareWrapper
 
 // Initialisation
 const router = express.Router()
@@ -19,7 +20,7 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, checkSecureCookie, validateAndRefreshCsrf, getPaymentRequest, getGatewayAccount, getService, getController)
+router.get(paths.index, checkSecureCookie, validateAndRefreshCsrf, getMandate, mandateStateEnforcerWrapper('cancel'), getGatewayAccount, getService, getController)
 
 // Export
 module.exports = {

--- a/app/cancel/index.js
+++ b/app/cancel/index.js
@@ -10,7 +10,7 @@ const checkSecureCookie = require('../../common/middleware/check-secure-cookie/c
 const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
 const getService = require('../../common/middleware/get-service/get-service').middleware
 const getMandate = require('../../common/middleware/get-mandate/get-mandate').middleware
-const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middlewareWrapper
+const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middleware
 
 // Initialisation
 const router = express.Router()

--- a/app/cancel/index.js
+++ b/app/cancel/index.js
@@ -5,11 +5,11 @@ const express = require('express')
 
 // Local dependencies
 const getController = require('./get.controller')
-const {validateAndRefreshCsrf} = require('../../common/middleware/csrf')
-const checkSecureCookie = require('../../common/middleware/check-secure-cookie').middleware
-const getPaymentRequest = require('../../common/middleware/get-mandate').middleware
-const getGatewayAccount = require('../../common/middleware/get-gateway-account').middleware
-const getService = require('../../common/middleware/get-service').middleware
+const {validateAndRefreshCsrf} = require('../../common/middleware/csrf/csrf')
+const checkSecureCookie = require('../../common/middleware/check-secure-cookie/check-secure-cookie').middleware
+const getPaymentRequest = require('../../common/middleware/get-mandate/get-mandate').middleware
+const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
+const getService = require('../../common/middleware/get-service/get-service').middleware
 
 // Initialisation
 const router = express.Router()

--- a/app/change-payment-method/index.js
+++ b/app/change-payment-method/index.js
@@ -5,10 +5,10 @@ const express = require('express')
 
 // Local dependencies
 const getController = require('./get.controller')
-const {validateAndRefreshCsrf} = require('../../common/middleware/csrf')
-const checkSecureCookie = require('../../common/middleware/check-secure-cookie').middleware
-const getPaymentRequest = require('../../common/middleware/get-mandate').middleware
-const getGatewayAccount = require('../../common/middleware/get-gateway-account').middleware
+const {validateAndRefreshCsrf} = require('../../common/middleware/csrf/csrf')
+const checkSecureCookie = require('../../common/middleware/check-secure-cookie/check-secure-cookie').middleware
+const getPaymentRequest = require('../../common/middleware/get-mandate/get-mandate').middleware
+const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
 
 // Initialisation
 const router = express.Router()

--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -1,14 +1,11 @@
 'use strict'
 const {getSessionVariable} = require('../../common/config/cookies')
-const {renderErrorView, renderPaymentCompletedSummary} = require('../../common/response')
+const {renderErrorView} = require('../../common/response')
 
 module.exports = (req, res) => {
   const mandate = res.locals.mandate
   const session = getSessionVariable(req, mandate.externalId)
-  if (mandate.state.status === 'pending') {
-    renderPaymentCompletedSummary(req, res, {'status': 'successful', 'returnUrl': mandate.returnUrl}
-    )
-  } else if (session.confirmationDetails) {
+  if (session.confirmationDetails) {
     const params = {
       mandateExternalId: mandate.externalId,
       accountHolderName: session.confirmationDetails.accountHolderName,

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -232,6 +232,5 @@ describe('confirmation get controller after successful payment', function () {
   it('should display the payment completed summary page', () => {
     expect($('form').length).to.equal(0)
     expect($('.heading-large.pending').length).to.equal(1)
-    expect($('#return-url').attr('href')).to.equal(mandateResponse.return_url)
   })
 })

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -230,7 +230,8 @@ describe('confirmation get controller after successful payment', function () {
   })
 
   it('should display the payment completed summary page', () => {
-    expect($('.heading-large').text().trim()).to.equal('Your payment was successful')
+    expect($('form').length).to.equal(0)
+    expect($('.heading-large.pending').length).to.equal(1)
     expect($('#return-url').attr('href')).to.equal(mandateResponse.return_url)
   })
 })

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -46,6 +46,9 @@ describe('confirmation get controller', function () {
       transaction: {
         amount: amount,
         description: description
+      },
+      state: {
+        status: 'started'
       }
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
@@ -133,6 +136,9 @@ describe('confirmation get controller with no confirmationDetails', function () 
       transaction: {
         amount: amount,
         description: description
+      },
+      state: {
+        status: 'started'
       }
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({

--- a/app/confirmation/index.js
+++ b/app/confirmation/index.js
@@ -6,11 +6,11 @@ const express = require('express')
 // Local dependencies
 const getController = require('./get.controller')
 const postController = require('./post.controller')
-const {validateAndRefreshCsrf} = require('../../common/middleware/csrf')
-const checkSecureCookie = require('../../common/middleware/check-secure-cookie').middleware
-const getMandate = require('../../common/middleware/get-mandate').middleware
-const getGatewayAccount = require('../../common/middleware/get-gateway-account').middleware
-const getService = require('../../common/middleware/get-service').middleware
+const {validateAndRefreshCsrf} = require('../../common/middleware/csrf/csrf')
+const checkSecureCookie = require('../../common/middleware/check-secure-cookie/check-secure-cookie').middleware
+const getMandate = require('../../common/middleware/get-mandate/get-mandate').middleware
+const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
+const getService = require('../../common/middleware/get-service/get-service').middleware
 
 // Initialisation
 const router = express.Router()

--- a/app/confirmation/index.js
+++ b/app/confirmation/index.js
@@ -11,7 +11,7 @@ const checkSecureCookie = require('../../common/middleware/check-secure-cookie/c
 const getMandate = require('../../common/middleware/get-mandate/get-mandate').middleware
 const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
 const getService = require('../../common/middleware/get-service/get-service').middleware
-const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middlewareWrapper
+const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middleware
 
 // Initialisation
 const router = express.Router()

--- a/app/confirmation/index.js
+++ b/app/confirmation/index.js
@@ -11,6 +11,7 @@ const checkSecureCookie = require('../../common/middleware/check-secure-cookie/c
 const getMandate = require('../../common/middleware/get-mandate/get-mandate').middleware
 const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
 const getService = require('../../common/middleware/get-service/get-service').middleware
+const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middlewareWrapper
 
 // Initialisation
 const router = express.Router()
@@ -20,8 +21,8 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, checkSecureCookie, validateAndRefreshCsrf, getMandate, getGatewayAccount, getService, getController)
-router.post(paths.index, checkSecureCookie, validateAndRefreshCsrf, getMandate, getGatewayAccount, getService, postController)
+router.get(paths.index, checkSecureCookie, validateAndRefreshCsrf, getMandate, mandateStateEnforcerWrapper('confirmation'), getGatewayAccount, getService, getController)
+router.post(paths.index, checkSecureCookie, validateAndRefreshCsrf, getMandate, mandateStateEnforcerWrapper('confirmation'), getGatewayAccount, getService, postController)
 
 // Export
 module.exports = {

--- a/app/confirmation/post.controller.tests.js
+++ b/app/confirmation/post.controller.tests.js
@@ -18,7 +18,10 @@ const mandateExternalId = 'sdfihsdufh2e'
 const gatewayAccoutExternalId = '1234567890'
 const mandateResponse = paymentFixtures.validOneOffMandateResponse({
   external_id: mandateExternalId,
-  gateway_account_external_id: gatewayAccoutExternalId
+  gateway_account_external_id: gatewayAccoutExternalId,
+  state: {
+    status: 'started'
+  }
 }).getPlain()
 const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
   gateway_account_external_id: gatewayAccoutExternalId

--- a/app/setup/get.controller.tests.js
+++ b/app/setup/get.controller.tests.js
@@ -46,7 +46,10 @@ describe('setup get controller', () => {
         amount: amount,
         description: description
       },
-      return_url: `/change-payment-method/${mandateExternalId}`
+      return_url: `/change-payment-method/${mandateExternalId}`,
+      state: {
+        status: 'started'
+      }
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -116,7 +119,10 @@ describe('setup get controller', () => {
         description: description
       },
       return_url: `/change-payment-method/${mandateExternalId}`,
-      payer: payer
+      payer: payer,
+      state: {
+        status: 'started'
+      }
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId

--- a/app/setup/index.js
+++ b/app/setup/index.js
@@ -11,6 +11,7 @@ const checkSecureCookie = require('../../common/middleware/check-secure-cookie/c
 const getMandate = require('../../common/middleware/get-mandate/get-mandate').middleware
 const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
 const getService = require('../../common/middleware/get-service/get-service').middleware
+const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middlewareWrapper
 
 // Initialisation
 const router = express.Router()
@@ -20,8 +21,8 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, checkSecureCookie, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, getMandate, getGatewayAccount, getService, getController)
-router.post(paths.index, checkSecureCookie, validateAndRefreshCsrf, getMandate, getGatewayAccount, postController)
+router.get(paths.index, checkSecureCookie, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, getMandate, mandateStateEnforcerWrapper('setup'), getGatewayAccount, getService, getController)
+router.post(paths.index, checkSecureCookie, validateAndRefreshCsrf, getMandate, mandateStateEnforcerWrapper('setup'), getGatewayAccount, postController)
 
 // Export
 module.exports = {

--- a/app/setup/index.js
+++ b/app/setup/index.js
@@ -6,11 +6,11 @@ const express = require('express')
 // Local dependencies
 const getController = require('./get.controller')
 const postController = require('./post.controller')
-const {validateAndRefreshCsrf, ensureSessionHasCsrfSecret} = require('../../common/middleware/csrf')
-const checkSecureCookie = require('../../common/middleware/check-secure-cookie').middleware
-const getMandate = require('../../common/middleware/get-mandate').middleware
-const getGatewayAccount = require('../../common/middleware/get-gateway-account').middleware
-const getService = require('../../common/middleware/get-service').middleware
+const {validateAndRefreshCsrf, ensureSessionHasCsrfSecret} = require('../../common/middleware/csrf/csrf')
+const checkSecureCookie = require('../../common/middleware/check-secure-cookie/check-secure-cookie').middleware
+const getMandate = require('../../common/middleware/get-mandate/get-mandate').middleware
+const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
+const getService = require('../../common/middleware/get-service/get-service').middleware
 
 // Initialisation
 const router = express.Router()

--- a/app/setup/index.js
+++ b/app/setup/index.js
@@ -11,7 +11,7 @@ const checkSecureCookie = require('../../common/middleware/check-secure-cookie/c
 const getMandate = require('../../common/middleware/get-mandate/get-mandate').middleware
 const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
 const getService = require('../../common/middleware/get-service/get-service').middleware
-const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middlewareWrapper
+const mandateStateEnforcerWrapper = require('../../common/middleware/mandate-state-enforcer/mandate-state-enforcer').middleware
 
 // Initialisation
 const router = express.Router()

--- a/app/setup/post.controller.tests.js
+++ b/app/setup/post.controller.tests.js
@@ -69,7 +69,10 @@ describe('setup post controller', () => {
   describe('when submitting the form for a valid mandate request', () => {
     const mandateResponse = paymentFixtures.validOneOffMandateResponse({
       external_id: mandateExternalId,
-      gateway_account_external_id: gatewayAccoutExternalId
+      gateway_account_external_id: gatewayAccoutExternalId,
+      state: {
+        status: 'started'
+      }
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -141,7 +144,10 @@ describe('setup post controller', () => {
   describe('should keep the field values when submitting the form with validation errors', () => {
     const mandateResponse = paymentFixtures.validOneOffMandateResponse({
       external_id: mandateExternalId,
-      gateway_account_external_id: gatewayAccoutExternalId
+      gateway_account_external_id: gatewayAccoutExternalId,
+      state: {
+        status: 'started'
+      }
     }).getPlain()
     const validateBankAccountResponse = {
       is_valid: true,
@@ -248,7 +254,10 @@ describe('setup post controller', () => {
     let $
     const mandateResponse = paymentFixtures.validOneOffMandateResponse({
       external_id: mandateExternalId,
-      gateway_account_external_id: gatewayAccoutExternalId
+      gateway_account_external_id: gatewayAccoutExternalId,
+      state: {
+        status: 'started'
+      }
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -345,7 +354,10 @@ describe('setup post controller', () => {
     let $
     const mandateResponse = paymentFixtures.validOneOffMandateResponse({
       external_id: mandateExternalId,
-      gateway_account_external_id: gatewayAccoutExternalId
+      gateway_account_external_id: gatewayAccoutExternalId,
+      state: {
+        status: 'started'
+      }
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId

--- a/common/middleware/check-secure-cookie/check-secure-cookie.js
+++ b/common/middleware/check-secure-cookie/check-secure-cookie.js
@@ -3,8 +3,8 @@ const logger = require('pino')()
 const _ = require('lodash')
 
 // local dependencies
-const {renderErrorView} = require('../response')
-const {getSessionVariable} = require('../config/cookies')
+const {renderErrorView} = require('../../response')
+const {getSessionVariable} = require('../../config/cookies')
 
 function middleware (req, res, next) {
   const mandateExternalId = req.params.mandateExternalId

--- a/common/middleware/check-secure-cookie/check-secure-cookie.tests.js
+++ b/common/middleware/check-secure-cookie/check-secure-cookie.tests.js
@@ -2,7 +2,7 @@ const sinon = require('sinon')
 const {expect} = require('chai')
 const assert = require('assert')
 const proxyquire = require('proxyquire')
-const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+const paymentFixtures = require('../../../test/fixtures/payments-fixtures')
 
 const setupFixtures = () => {
   const mandate = paymentFixtures.validMandate()
@@ -11,7 +11,7 @@ const setupFixtures = () => {
   const renderErrorView = sinon.spy()
 
   const checkSecureCookie = proxyquire('./check-secure-cookie', {
-    '../response': {renderErrorView}
+    '../../response': {renderErrorView}
   }).middleware
 
   return {res, next, renderErrorView, mandate, checkSecureCookie}

--- a/common/middleware/correlation-header/correlation-header.js
+++ b/common/middleware/correlation-header/correlation-header.js
@@ -1,5 +1,5 @@
 'use strict'
-const config = require('../config/index')
+const config = require('../../config/index')
 // Constants
 const CORRELATION_HEADER = config.CORRELATION_HEADER
 

--- a/common/middleware/csrf/csrf.js
+++ b/common/middleware/csrf/csrf.js
@@ -5,8 +5,8 @@ const csrf = require('csrf')
 const logger = require('pino')()
 
 // Local Dependencies
-const {renderErrorView} = require('../response')
-const {getSessionVariable, setSessionVariable} = require('../../common/config/cookies')
+const {renderErrorView} = require('../../response')
+const {getSessionVariable, setSessionVariable} = require('../../config/cookies')
 // Assignments and Variables
 const errorMsg = 'There is a problem with the payments platform'
 

--- a/common/middleware/csrf/csrf.tests.js
+++ b/common/middleware/csrf/csrf.tests.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const sinon = require('sinon')
 const assert = require('assert')
 const proxyquire = require('proxyquire')

--- a/common/middleware/csrf/csrf.tests.js
+++ b/common/middleware/csrf/csrf.tests.js
@@ -13,7 +13,7 @@ describe('CSRF', function () {
       .withArgs("it's a secret")
       .returns('newly-created token')
 
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'),
+    const csrf = proxyquire('./csrf',
       {'csrf': () => {
         return {
           verify: verify,
@@ -47,8 +47,8 @@ describe('CSRF', function () {
 
   it('should error if session not present', function () {
     const renderErrorView = sinon.spy()
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'), {
-      '../response': {
+    const csrf = proxyquire('./csrf', {
+      '../../response': {
         renderErrorView: renderErrorView
       }
     }).validateAndRefreshCsrf
@@ -69,8 +69,8 @@ describe('CSRF', function () {
 
   it('should error if session has no CSRF secret', function () {
     const renderErrorView = sinon.spy()
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'), {
-      '../response': {
+    const csrf = proxyquire('./csrf', {
+      '../../response': {
         renderErrorView: renderErrorView
       }
     }).validateAndRefreshCsrf
@@ -95,8 +95,8 @@ describe('CSRF', function () {
     const verify = sinon.stub()
       .withArgs("it's a secret", 'forged token - call the police')
       .returns(false)
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'), {
-      '../response': {
+    const csrf = proxyquire('./csrf', {
+      '../../response': {
         renderErrorView: renderErrorView
       },
       'csrf': () => {
@@ -130,7 +130,7 @@ describe('CSRF', function () {
       .withArgs("it's a secret")
       .returns('newly-created token')
 
-    const csrf = proxyquire(path.join(__dirname, '/../../common/middleware/csrf'),
+    const csrf = proxyquire('./csrf',
       {'csrf': () => {
         return {
           verify: verify,

--- a/common/middleware/get-gateway-account/get-gateway-account.js
+++ b/common/middleware/get-gateway-account/get-gateway-account.js
@@ -6,8 +6,8 @@ const logger = require('pino')()
 const {Cache} = require('memory-cache')
 
 // local dependencies
-const {renderErrorView} = require('../response')
-const adminusersClient = require('../clients/adminusers-client')
+const {renderErrorView} = require('../../response')
+const connectorClient = require('../../clients/connector-client')
 
 // constants
 const CACHE_MAX_AGE = parseInt(process.env.CACHE_MAX_AGE || 15 * 60 * 1000) // default to 15 mins
@@ -19,26 +19,26 @@ function middleware (req, res, next) {
     logger.error(`[${req.correlationId}] Failed to retrieve gateway account external id from res.locals`)
     return renderErrorView(req, res)
   }
-  const cachedService = cache.get(`${gatewayAccountExternalId}.service`)
-  if (cachedService) {
-    res.locals.service = cachedService
+
+  const cachedGatewayAccount = cache.get(gatewayAccountExternalId)
+  if (cachedGatewayAccount) {
+    res.locals.gatewayAccount = cachedGatewayAccount
     next()
   } else {
-    adminusersClient.retrieveService(gatewayAccountExternalId,
-      req.correlationId)
-      .then(service => {
-        cache.put(`${gatewayAccountExternalId}.service`, service, CACHE_MAX_AGE)
-        res.locals.service = service
+    connectorClient.retrieveGatewayAccount(gatewayAccountExternalId, req.correlationId)
+      .then(gatewayAccount => {
+        cache.put(gatewayAccountExternalId, gatewayAccount, CACHE_MAX_AGE)
+        res.locals.gatewayAccount = gatewayAccount
         next()
       })
       .catch(() => {
-        logger.error(
-          `[${req.correlationId}] Failed to load service from adminusers: ${gatewayAccountExternalId}`)
+        logger.error(`[${req.correlationId}] Failed to load gateway account from connector: ${gatewayAccountExternalId}`)
         renderErrorView(req, res)
       })
   }
 }
 
 module.exports = {
+  CACHE_MAX_AGE,
   middleware
 }

--- a/common/middleware/get-gateway-account/get-gateway-account.tests.js
+++ b/common/middleware/get-gateway-account/get-gateway-account.tests.js
@@ -1,7 +1,7 @@
 const sinon = require('sinon')
 const {expect} = require('chai')
 const proxyquire = require('proxyquire')
-const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+const paymentFixtures = require('../../../test/fixtures/payments-fixtures')
 
 const MANDATE = paymentFixtures.validMandate()
 const GATEWAY_ACCOUNT = paymentFixtures.validGatewayAccount({
@@ -20,9 +20,9 @@ const setup = () => {
   }
 
   const getGatewayAccount = proxyquire('./get-gateway-account', {
-    '../response': {renderErrorView: fixtures.renderErrorView},
+    '../../response': {renderErrorView: fixtures.renderErrorView},
     'memory-cache': { Cache: function () { return fixtures.cache } },
-    '../clients/connector-client': fixtures.connectorClient
+    '../../clients/connector-client': fixtures.connectorClient
   })
 
   return Object.assign(fixtures, {getGatewayAccount})

--- a/common/middleware/get-mandate/get-mandate.js
+++ b/common/middleware/get-mandate/get-mandate.js
@@ -5,8 +5,8 @@ const _ = require('lodash')
 const logger = require('pino')()
 
 // local dependencies
-const {renderErrorView} = require('../response')
-const connectorClient = require('../clients/connector-client')
+const {renderErrorView} = require('../../response')
+const connectorClient = require('../../clients/connector-client')
 
 function middleware (req, res, next) {
   const mandateExternalId = _.get(res, 'locals.mandateExternalId')

--- a/common/middleware/get-mandate/get-mandate.tests.js
+++ b/common/middleware/get-mandate/get-mandate.tests.js
@@ -1,7 +1,7 @@
 const sinon = require('sinon')
 const {expect} = require('chai')
 const proxyquire = require('proxyquire')
-const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+const paymentFixtures = require('../../../test/fixtures/payments-fixtures')
 
 const MANDATE = paymentFixtures.validMandate()
 
@@ -13,8 +13,8 @@ const setupFixtures = () => {
   const renderErrorView = sinon.spy()
 
   const getMandate = proxyquire('./get-mandate', {
-    '../response': {renderErrorView: renderErrorView},
-    '../clients/connector-client': connectorClient
+    '../../response': {renderErrorView: renderErrorView},
+    '../../clients/connector-client': connectorClient
   })
 
   return {req, res, next, renderErrorView, connectorClient, getMandate}

--- a/common/middleware/get-service/get-service.tests.js
+++ b/common/middleware/get-service/get-service.tests.js
@@ -1,7 +1,7 @@
 const sinon = require('sinon')
 const {expect} = require('chai')
 const proxyquire = require('proxyquire')
-const paymentFixtures = require('../../test/fixtures/payments-fixtures')
+const paymentFixtures = require('../../../test/fixtures/payments-fixtures')
 
 const GATEWAY_ACCOUNT_ID = 'DIRECT_DEBIT:23823o2iousda'
 const SERVICE = paymentFixtures.validService({
@@ -16,8 +16,8 @@ const setupFixtures = () => {
   const renderErrorView = sinon.spy()
 
   const getService = proxyquire('./get-service', {
-    '../response': {renderErrorView: renderErrorView},
-    '../clients/adminusers-client': adminusersClient
+    '../../response': {renderErrorView: renderErrorView},
+    '../../clients/adminusers-client': adminusersClient
   })
 
   return {req, res, next, renderErrorView, adminusersClient, getService}

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -1,0 +1,45 @@
+// npm dependencies
+const _ = require('lodash')
+const logger = require('pino')()
+
+// local dependencies
+const {renderErrorView} = require('../../response')
+
+const pageStateMap = {
+  'setup': ['started'],
+  'confirmation': ['started']
+}
+
+const stateToErrorMessageMap = {
+  'started': 'msg',
+  'cancelled': 'You cancelled your request. Start again',
+  'pending': 'Being processed. Refer to your email for contact details',
+  'failed': 'No longer in process. Start again',
+  'active': 'Your mandate has been setup. Refer to your email for contact details',
+  'created': 'Technical error',
+  'submitted': 'Technical error'
+}
+
+function middlewareWrapper (page) {
+  return (req, res, next) => {
+    const mandate = res.locals.mandate
+    if (mandate) {
+      const mandateState = mandate.state.status
+      const stateIsAllowed = pageStateMap[page].includes(mandateState)
+
+      if (stateIsAllowed) {
+        next()
+      } else {
+        const errorMessage = _.get(stateToErrorMessageMap, mandateState, 'An error has occurred')
+        logger.info(`[${req.correlationId}] Mandate ${mandate.externalId} is in state ${mandateState} and not valid for page ${page}`)
+        renderErrorView(req, res, errorMessage, 500, 'aghhhhhhhhhhhhhh!')
+      }
+    } else {
+      next()
+    }
+  }
+}
+
+module.exports = {
+  middlewareWrapper
+}

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -7,7 +7,8 @@ const {renderErrorView} = require('../../response')
 
 const pageStateMap = {
   'setup': ['started'],
-  'confirmation': ['started']
+  'confirmation': ['started', 'pending'],
+  'cancel': ['cancelled', 'inactive']
 }
 
 const stateToErrorMessageMap = {
@@ -16,7 +17,8 @@ const stateToErrorMessageMap = {
   'failed': 'No longer in process. Start again',
   'active': 'Your mandate has been setup. Refer to your email for contact details',
   'created': 'Technical error',
-  'submitted': 'Technical error'
+  'submitted': 'Technical error',
+  'inactive': 'You cancelled your request. Start again'
 }
 
 function middlewareWrapper (page) {

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -43,7 +43,7 @@ const mandateStateToMessageMap = {
   }
 }
 
-function middlewareWrapper (page) {
+function middleware (page) {
   return (req, res, next) => {
     const mandate = _.get(res, 'locals.mandate')
     if (mandate) {
@@ -70,5 +70,5 @@ function middlewareWrapper (page) {
 }
 
 module.exports = {
-  middlewareWrapper
+  middleware
 }

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -8,7 +8,7 @@ const {response} = require('../../response')
 const pageToValidMandateStateMap = {
   'setup': ['started'],
   'confirmation': ['started'],
-  'cancel': ['cancelled', 'inactive']
+  'cancel': ['started']
 }
 
 const mandateStateToMessageMap = {

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -12,13 +12,35 @@ const pageToValidMandateStateMap = {
 }
 
 const mandateStateToMessageMap = {
-  'cancelled': 'You cancelled your request. Start again',
-  'pending': 'Being processed. Refer to your email for contact details',
-  'failed': 'No longer in process. Start again',
-  'active': 'Your mandate has been setup. Refer to your email for contact details',
-  'created': 'Technical error',
-  'submitted': 'Technical error',
-  'inactive': 'You cancelled your request. Start again'
+  cancelled: {
+    heading: 'You have cancelled the Direct Debit mandate setup',
+    message: 'Your mandate has not been set up.',
+    includeReturnUrl: true
+  },
+  inactive: {
+    heading: 'You have cancelled the Direct Debit mandate setup',
+    message: 'Your mandate has not been set up.',
+    includeReturnUrl: true
+  },
+  pending: {
+    heading: 'Your Direct Debit mandate is being processed',
+    message: 'Check your confirmation email for details of your mandate.  '
+  },
+  failed: {
+    heading: 'Your Direct Debit mandate has not been set up',
+    message: 'You might have entered your details incorrectly or your session may have timed out.',
+    includeReturnUrl: true
+  },
+  active: {
+    heading: 'Your Direct Debit mandate has been set up',
+    message: 'We have sent you a confirmation email with your mandate details. '
+  },
+
+  default: {
+    heading: 'Sorry, we are experiencing technical problems',
+    message: '',
+    includeReturnUrl: true
+  }
 }
 
 function middlewareWrapper (page) {
@@ -31,13 +53,14 @@ function middlewareWrapper (page) {
       if (stateIsAllowed) {
         next()
       } else {
-        const message = _.get(mandateStateToMessageMap, mandateState, 'An error has occurred')
+        const content = _.get(mandateStateToMessageMap, mandateState, mandateStateToMessageMap.default)
         logger.info(`[${req.correlationId}] Mandate ${mandate.externalId} is in state ${mandateState} and not valid for page ${page}`)
         response(req, res, 'common/templates/mandate_state_page', {
-          message,
-          heading: 'Heading',
+          message: content.message,
+          heading: content.heading,
           returnUrl: mandate.returnUrl,
-          status: mandateState
+          status: mandateState,
+          includeReturnUrl: content.includeReturnUrl
         })
       }
     } else {

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -11,7 +11,6 @@ const pageStateMap = {
 }
 
 const stateToErrorMessageMap = {
-  'started': 'msg',
   'cancelled': 'You cancelled your request. Start again',
   'pending': 'Being processed. Refer to your email for contact details',
   'failed': 'No longer in process. Start again',
@@ -32,7 +31,7 @@ function middlewareWrapper (page) {
       } else {
         const errorMessage = _.get(stateToErrorMessageMap, mandateState, 'An error has occurred')
         logger.info(`[${req.correlationId}] Mandate ${mandate.externalId} is in state ${mandateState} and not valid for page ${page}`)
-        renderErrorView(req, res, errorMessage, 500, 'aghhhhhhhhhhhhhh!')
+        renderErrorView(req, res, errorMessage, 500, 'Error', true)
       }
     } else {
       next()

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -7,7 +7,7 @@ const {response} = require('../../response')
 
 const pageToValidMandateStateMap = {
   'setup': ['started'],
-  'confirmation': ['started', 'pending'],
+  'confirmation': ['started'],
   'cancel': ['cancelled', 'inactive']
 }
 
@@ -36,7 +36,8 @@ function middlewareWrapper (page) {
         response(req, res, 'common/templates/mandate_state_page', {
           message,
           heading: 'Heading',
-          returnUrl: mandate.returnUrl
+          returnUrl: mandate.returnUrl,
+          status: mandateState
         })
       }
     } else {

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -59,7 +59,7 @@ describe('Mandate state enforcer', () => {
       })
       mandateStateEnforcer.middlewareWrapper('setup')(req, res, next, renderErrorView)
       expect(next.called).to.equal(false)
-      sinon.assert.calledWith(renderErrorView, req, res, 'You cancelled your request. Start again')
+      sinon.assert.calledWith(renderErrorView, req, res, 'You cancelled your request. Start again', 500, 'aghhhhhhhhhhhhhh!', true)
     })
   })
 })

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -1,0 +1,65 @@
+const sinon = require('sinon')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+
+const setupFixtures = (response) => {
+  const req = {params: {}, correlationId: 'correlation-id'}
+  const res = response || {locals: {}}
+  const next = sinon.spy()
+  const renderErrorView = sinon.spy()
+
+  const mandateStateEnforcer = proxyquire('./mandate-state-enforcer', {
+    '../../response': {renderErrorView: renderErrorView}
+  })
+
+  return {req, res, next, renderErrorView, mandateStateEnforcer}
+}
+
+describe('Mandate state enforcer', () => {
+  describe('when user on set up page and no mandate', () => {
+    const {req, res, next, ...rest} = setupFixtures()
+
+    before(() => {
+      rest.mandateStateEnforcer.middlewareWrapper('setup')(req, res, next)
+    })
+
+    it('should set the service that has been retrieved in res.locals', () => {
+      expect(true).to.equal(true)
+    })
+    it('should call next if mandate not present', () => {
+      expect(next.called).to.equal(true)
+    })
+  })
+
+  describe('when user on set up page with mandate', () => {
+    it('should call next for mandate status of "started" on page "setup"', () => {
+      const {req, res, next, ...rest} = setupFixtures({
+        locals: {
+          mandate: {
+            state: {
+              status: 'started'
+            }
+          }
+        }
+      })
+      rest.mandateStateEnforcer.middlewareWrapper('setup')(req, res, next)
+
+      expect(next.called).to.equal(true)
+    })
+
+    it('should render error page for mandate status of "cancelled" on page "setup"', () => {
+      const {req, res, next, renderErrorView, mandateStateEnforcer} = setupFixtures({
+        locals: {
+          mandate: {
+            state: {
+              status: 'cancelled'
+            }
+          }
+        }
+      })
+      mandateStateEnforcer.middlewareWrapper('setup')(req, res, next, renderErrorView)
+      expect(next.called).to.equal(false)
+      sinon.assert.calledWith(renderErrorView, req, res, 'You cancelled your request. Start again')
+    })
+  })
+})

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -63,10 +63,11 @@ describe('Mandate state enforcer', () => {
       mandateStateEnforcer.middlewareWrapper('setup')(req, res, next, response)
       expect(next.called).to.equal(false)
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
-        message: 'You cancelled your request. Start again',
-        heading: 'Heading',
+        message: 'Your mandate has not been set up.',
+        heading: 'You have cancelled the Direct Debit mandate setup',
         status: 'cancelled',
-        returnUrl
+        returnUrl,
+        includeReturnUrl: true
       })
     })
   })
@@ -100,10 +101,11 @@ describe('Mandate state enforcer', () => {
       mandateStateEnforcer.middlewareWrapper('confirmation')(req, res, next, response)
       expect(next.called).to.equal(false)
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
-        message: 'You cancelled your request. Start again',
-        heading: 'Heading',
+        message: 'Your mandate has not been set up.',
+        heading: 'You have cancelled the Direct Debit mandate setup',
         status: 'cancelled',
-        returnUrl
+        returnUrl,
+        includeReturnUrl: true
       })
     })
   })

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -22,7 +22,7 @@ describe('Mandate state enforcer', () => {
     const {req, res, next, ...rest} = setupFixtures()
 
     before(() => {
-      rest.mandateStateEnforcer.middlewareWrapper('setup')(req, res, next)
+      rest.mandateStateEnforcer.middleware('setup')(req, res, next)
     })
 
     it('should set the service that has been retrieved in res.locals', () => {
@@ -44,7 +44,7 @@ describe('Mandate state enforcer', () => {
           }
         }
       })
-      rest.mandateStateEnforcer.middlewareWrapper('setup')(req, res, next)
+      rest.mandateStateEnforcer.middleware('setup')(req, res, next)
 
       expect(next.called).to.equal(true)
     })
@@ -60,7 +60,7 @@ describe('Mandate state enforcer', () => {
           }
         }
       })
-      mandateStateEnforcer.middlewareWrapper('setup')(req, res, next, response)
+      mandateStateEnforcer.middleware('setup')(req, res, next, response)
       expect(next.called).to.equal(false)
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'Your mandate has not been set up.',
@@ -82,7 +82,7 @@ describe('Mandate state enforcer', () => {
           }
         }
       })
-      rest.mandateStateEnforcer.middlewareWrapper('confirmation')(req, res, next)
+      rest.mandateStateEnforcer.middleware('confirmation')(req, res, next)
 
       expect(next.called).to.equal(true)
     })
@@ -98,7 +98,7 @@ describe('Mandate state enforcer', () => {
           }
         }
       })
-      mandateStateEnforcer.middlewareWrapper('confirmation')(req, res, next, response)
+      mandateStateEnforcer.middleware('confirmation')(req, res, next, response)
       expect(next.called).to.equal(false)
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'Your mandate has not been set up.',

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -59,7 +59,7 @@ describe('Mandate state enforcer', () => {
       })
       mandateStateEnforcer.middlewareWrapper('setup')(req, res, next, renderErrorView)
       expect(next.called).to.equal(false)
-      sinon.assert.calledWith(renderErrorView, req, res, 'You cancelled your request. Start again', 500, 'aghhhhhhhhhhhhhh!', true)
+      sinon.assert.calledWith(renderErrorView, req, res, 'You cancelled your request. Start again', 500, 'Error', true)
     })
   })
 })

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -65,6 +65,7 @@ describe('Mandate state enforcer', () => {
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'You cancelled your request. Start again',
         heading: 'Heading',
+        status: 'cancelled',
         returnUrl
       })
     })
@@ -101,6 +102,7 @@ describe('Mandate state enforcer', () => {
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'You cancelled your request. Start again',
         heading: 'Heading',
+        status: 'cancelled',
         returnUrl
       })
     })

--- a/common/response.js
+++ b/common/response.js
@@ -8,11 +8,14 @@ function response (req, res, template, data) {
   return res.render(template, data)
 }
 
-function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
+function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500, heading = 'Sorry, we’re experiencing technical problems') {
   logger.error(`[${req.correlationId}] ${status} An error has occurred. Rendering error view -`, {errorMessage: msg})
   res.setHeader('Content-Type', 'text/html')
   res.status(status)
-  res.render('common/templates/error', {'message': msg})
+  res.render('common/templates/error', {
+    'message': msg,
+    'heading': heading
+  })
 }
 
 function renderPaymentCompletedSummary (req, res, params) {

--- a/common/response.js
+++ b/common/response.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const logger = require('pino')()
+const _ = require('lodash')
 
 const ERROR_MESSAGE = 'There is a problem with the payments platform'
 
@@ -8,14 +9,21 @@ function response (req, res, template, data) {
   return res.render(template, data)
 }
 
-function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500, heading = 'Sorry, we’re experiencing technical problems') {
+function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500, heading = 'Sorry, we’re experiencing technical problems', setReturnUrl = false) {
   logger.error(`[${req.correlationId}] ${status} An error has occurred. Rendering error view -`, {errorMessage: msg})
   res.setHeader('Content-Type', 'text/html')
   res.status(status)
-  res.render('common/templates/error', {
+  const returnUrl = setReturnUrl && _.get(res, 'locals.mandate.returnUrl')
+  let options = {
     'message': msg,
     'heading': heading
-  })
+  }
+
+  if (returnUrl) {
+    options.returnUrl = returnUrl
+  }
+
+  res.render('common/templates/error', options)
 }
 
 function renderPaymentCompletedSummary (req, res, params) {

--- a/common/response.js
+++ b/common/response.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const logger = require('pino')()
-const _ = require('lodash')
 
 const ERROR_MESSAGE = 'There is a problem with the payments platform'
 
@@ -9,23 +8,12 @@ function response (req, res, template, data) {
   return res.render(template, data)
 }
 
-function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500, heading = 'Sorry, we’re experiencing technical problems', setReturnUrl = false) {
+function renderErrorView (req, res, msg = ERROR_MESSAGE, status = 500) {
   logger.error(`[${req.correlationId}] ${status} An error has occurred. Rendering error view -`, {errorMessage: msg})
   res.setHeader('Content-Type', 'text/html')
   res.status(status)
-  const returnUrl = setReturnUrl && _.get(res, 'locals.mandate.returnUrl')
-  let options = {
-    'message': msg,
-    'heading': heading
-  }
-
-  if (returnUrl) {
-    options.returnUrl = returnUrl
-  }
-
-  res.render('common/templates/error', options)
+  res.render('common/templates/error', {'message': msg})
 }
-
 function renderPaymentCompletedSummary (req, res, params) {
   res.setHeader('Content-Type', 'text/html')
   res.status(200)
@@ -33,7 +21,7 @@ function renderPaymentCompletedSummary (req, res, params) {
 }
 
 module.exports = {
-  response: response,
-  renderErrorView: errorResponse,
-  renderPaymentCompletedSummary: renderPaymentCompletedSummary
+  response,
+  renderErrorView,
+  renderPaymentCompletedSummary
 }

--- a/common/templates/error.njk
+++ b/common/templates/error.njk
@@ -6,11 +6,8 @@
   <main id="content" role="main">
     <div class="grid-row">
       <div class="column-two-thirds">
-        <h1 class="heading-large">{{heading}}</h1>
+        <h1 class="heading-large">Sorry, we’re experiencing technical problems</h1>
           <p id="errorMsg">{{message}}</p>
-          {% if returnUrl %}
-          <a href={{returnUrl}}> Go back to service </a>
-          {% endif %}
       </div>
     </div>
   </main>

--- a/common/templates/error.njk
+++ b/common/templates/error.njk
@@ -8,6 +8,9 @@
       <div class="column-two-thirds">
         <h1 class="heading-large">{{heading}}</h1>
           <p id="errorMsg">{{message}}</p>
+          {% if returnUrl %}
+          <a href={{returnUrl}}> Go back to service </a>
+          {% endif %}
       </div>
     </div>
   </main>

--- a/common/templates/error.njk
+++ b/common/templates/error.njk
@@ -6,7 +6,7 @@
   <main id="content" role="main">
     <div class="grid-row">
       <div class="column-two-thirds">
-        <h1 class="heading-large">Sorry, we’re experiencing technical problems</h1>
+        <h1 class="heading-large">{{heading}}</h1>
           <p id="errorMsg">{{message}}</p>
       </div>
     </div>

--- a/common/templates/mandate_state_page.njk
+++ b/common/templates/mandate_state_page.njk
@@ -9,8 +9,8 @@
     <div class="column-two-thirds">
       <h1 class="heading-large {{ status }}"> {{ heading }} </h1>
       <p class="lede">{{ message }}</p>
-      {% if returnUrl %}
-      <a href="{{ returnUrl }}" id="return-url" class="lede"> View your payment summary </a>
+      {% if includeReturnUrl %}
+      <p class="lede">You can <a href="{{ returnUrl }}" id="return-url" class="lede">  go back and try again</a>.</p>
       {% endif %}
     </div>
   </main>

--- a/common/templates/mandate_state_page.njk
+++ b/common/templates/mandate_state_page.njk
@@ -1,0 +1,17 @@
+{% extends "common/templates/layout.njk" %}
+
+{% block page_title %}
+  {{heading}}
+{% endblock %}
+
+{% block content %}
+  <main id="content" class="content-wrapper error-pages grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large {{ status }}"> {{ heading }} </h1>
+      <p class="lede">{{ message }}</p>
+      {% if returnUrl %}
+      <a href="{{ returnUrl }}" id="return-url" class="lede"> View your payment summary </a>
+      {% endif %}
+    </div>
+  </main>
+{% endblock %}

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const nunjucks = require('nunjucks')
 // Local dependencies
 const router = require('./app/router')
 const noCache = require('./common/utils/no-cache')
-const correlationHeader = require('./common/middleware/correlation-header')
+const correlationHeader = require('./common/middleware/correlation-header/correlation-header')
 const cookieConfig = require('./common/config/cookies')
 
 // Global constants

--- a/server.js
+++ b/server.js
@@ -2,7 +2,9 @@
 const path = require('path')
 
 // Please leave here even though it looks unused - this enables Node.js metrics to be pushed to Hosted Graphite
-require('./common/utils/metrics').metrics()
+if (!process.env.DISABLE_APPMETRICS) {
+  require('./common/utils/metrics').metrics()
+}
 
 // npm dependencies
 const express = require('express')


### PR DESCRIPTION
## Mandate state enforcer
This PR introduces a mandate state enforcer, a middleware to ensure that the current state of the mandate is compatible with where the user is in the flow https://github.com/alphagov/pay-direct-debit-frontend/pull/90/files#diff-08a2dcbb1afa1c62e78f72a9c4b5dde5

It does this in a similar way to how card frontend does it, by defining for each page a set of compatible mandate states. NB. We have only paid attention to mandate state rather than both payment and mandate since my understanding is that in the case of one off payments the state of the payment request mirrors that of the mandate.

As it stands the compatible states for each page are as follows

| Page        | Compatible States           |
| ------------- |:-------------:| 
| setup      | started |
| confirmation      | started      |
| cancel | started      |

The only tests included are unit tests for the middleware itself, as we felt the functionality is sufficiently simple not to warrant more extensive integration tests. We have not tested every possible error case, just the general mechanism for producing an error page with the the correct message etc. 

with @danworth 
