### PR TITLE
PP-3671 Handle ON_DEMAND payments

### DIFF
--- a/app/cancel/get.controller.js
+++ b/app/cancel/get.controller.js
@@ -9,7 +9,7 @@ module.exports = (req, res) => {
   const params = {
     returnUrl: mandate.returnUrl
   }
-  connectorClient.payment.cancelPaymentRequest(mandate.gatewayAccountExternalId, mandate.externalId, req.correlationId)
+  connectorClient.payment.cancelTransaction(mandate.gatewayAccountExternalId, mandate.externalId, req.correlationId)
     .then(() => {
       return res.render('app/cancel/get', params)
     })

--- a/app/change-payment-method/index.js
+++ b/app/change-payment-method/index.js
@@ -7,7 +7,7 @@ const express = require('express')
 const getController = require('./get.controller')
 const {validateAndRefreshCsrf} = require('../../common/middleware/csrf/csrf')
 const checkSecureCookie = require('../../common/middleware/check-secure-cookie/check-secure-cookie').middleware
-const getPaymentRequest = require('../../common/middleware/get-mandate/get-mandate').middleware
+const getTransaction = require('../../common/middleware/get-mandate/get-mandate').middleware
 const getGatewayAccount = require('../../common/middleware/get-gateway-account/get-gateway-account').middleware
 
 // Initialisation
@@ -18,7 +18,7 @@ const paths = {
 }
 
 // Routing
-router.get(paths.index, checkSecureCookie, validateAndRefreshCsrf, getPaymentRequest, getGatewayAccount, getController)
+router.get(paths.index, checkSecureCookie, validateAndRefreshCsrf, getTransaction, getGatewayAccount, getController)
 
 // Export
 module.exports = {

--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -4,6 +4,7 @@ const {renderErrorView} = require('../../common/response')
 
 module.exports = (req, res) => {
   const mandate = res.locals.mandate
+  const transaction = mandate.transaction || {}
   const session = getSessionVariable(req, mandate.externalId)
   if (session.confirmationDetails) {
     const params = {
@@ -13,8 +14,8 @@ module.exports = (req, res) => {
       accountNumber: session.confirmationDetails.accountNumber,
       sortCode: session.confirmationDetails.sortCode.match(/.{2}/g).join(' '),
       returnUrl: mandate.returnUrl,
-      description: mandate.transaction.description,
-      amount: mandate.transaction.amount,
+      description: transaction.description,
+      amount: transaction.amount,
       paymentAction: 'confirmation'
     }
     res.render('app/confirmation/get', params)

--- a/app/confirmation/get.controller.js
+++ b/app/confirmation/get.controller.js
@@ -8,6 +8,7 @@ module.exports = (req, res) => {
   if (session.confirmationDetails) {
     const params = {
       mandateExternalId: mandate.externalId,
+      mandateType: mandate.type,
       accountHolderName: session.confirmationDetails.accountHolderName,
       accountNumber: session.confirmationDetails.accountNumber,
       sortCode: session.confirmationDetails.sortCode.match(/.{2}/g).join(' '),

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -14,7 +14,7 @@ const getApp = require('../../server').getApp
 const paymentFixtures = require('../../test/fixtures/payments-fixtures')
 const {CookieBuilder} = require('../../test/test_helpers/cookie-helper')
 
-describe('confirmation get controller', function () {
+describe('confirmation one-off payment get controller', function () {
   let response, $
   const mandateExternalId = 'sdfihsdufh2e'
   const gatewayAccoutExternalId = '1234567890'
@@ -98,8 +98,106 @@ describe('confirmation get controller', function () {
     expect($(`#amount`).text()).to.equal(`£10.00`)
   })
 
+  it('should display the enter direct debit page with a link to cancel the payment', () => {
+    expect($(`.cancel-link`).attr('href')).to.equal(`/cancel/${mandateExternalId}`)
+  })
+
+  it('should display the confirmation page with a back link to the setup page', () => {
+    const url = setup.paths.index.replace(':mandateExternalId', mandateExternalId)
+    expect($('.link-back').attr('href')).to.equal(url)
+  })
+
+  it('should display the enter direct debit page with a link to the direct debit guarantee', () => {
+    expect($(`.direct-debit-guarantee`).find('a').attr('href')).to.equal(`/direct-debit-guarantee/confirmation/${mandateExternalId}`)
+  })
+  it('should display merchant details in the footer', () => {
+    expect($(`.merchant-details-line-1`).text()).to.equal(`Service provided by ${service.merchant_details.name}`)
+    expect($(`.merchant-details-line-2`).text()).to.equal(`${service.merchant_details.address_line1}, ${service.merchant_details.address_line2}, ${service.merchant_details.address_city} ${service.merchant_details.address_postcode} United Kingdom`)
+    expect($(`.merchant-details-phone-number`).text()).to.equal(`Phone: ${service.merchant_details.telephone_number}`)
+    expect($(`.merchant-details-email`).text()).to.equal(`Email: ${service.merchant_details.email}`)
+  })
+})
+
+describe('confirmation on-demand payment get controller', function () {
+  let response, $
+  const mandateExternalId = 'sdfihsdufh2e'
+  const gatewayAccoutExternalId = '1234567890'
+  const service = { external_id: 'eisuodfkf',
+    name: 'GOV.UK Direct Cake service',
+    gateway_account_ids: [gatewayAccoutExternalId],
+    merchant_details: {
+      name: 'Silvia needs coffee',
+      address_line1: 'Anywhere',
+      address_line2: 'Anyhow',
+      address_city: 'London',
+      address_postcode: 'AW1H 9UX',
+      address_country: 'GB',
+      telephone_number: '28398203',
+      email: 'bla@bla.test'
+    }
+  }
+  const accountName = 'bla'
+  const sortCode = '123456'
+  const formattedSortCode = '12 34 56'
+  const accountNumber = '12345678'
+
+  before(done => {
+    const mandateResponse = paymentFixtures.validOnDemandMandateResponse({
+      external_id: mandateExternalId,
+      gateway_account_external_id: gatewayAccoutExternalId,
+      state: {
+        status: 'started'
+      }
+    }).getPlain()
+    const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
+      gateway_account_external_id: gatewayAccoutExternalId
+    })
+    const payer = paymentFixtures.validPayer({
+      account_holder_name: accountName,
+      sort_code: sortCode,
+      account_number: accountNumber
+    })
+    const cookieHeader = new CookieBuilder(
+      gatewayAccoutExternalId,
+      mandateExternalId
+    )
+      .withCsrfSecret('123')
+      .withConfirmationDetails(payer)
+      .build()
+    nock(config.CONNECTOR_URL)
+      .get(`/v1/accounts/${gatewayAccoutExternalId}/mandates/${mandateExternalId}`)
+      .reply(200, mandateResponse)
+    nock(config.CONNECTOR_URL)
+      .get(`/v1/api/accounts/${gatewayAccoutExternalId}`)
+      .reply(200, gatewayAccountResponse)
+    nock(config.ADMINUSERS_URL).get(`/v1/api/services?gatewayAccountId=${gatewayAccoutExternalId}`).reply(200, service)
+    supertest(getApp())
+      .get(`/confirmation/${mandateExternalId}`)
+      .set('cookie', cookieHeader)
+      .end((err, res) => {
+        response = res
+        $ = cheerio.load(res.text)
+        done(err)
+      })
+  })
+
+  it('should return HTTP 200 status', () => {
+    expect(response.statusCode).to.equal(200)
+  })
+
+  it('should display the confirmation page with the payer details', () => {
+    expect($('#account-holder-name').text()).to.equal(accountName)
+    expect($('#sort-code').text()).to.equal(formattedSortCode)
+    expect($('#account-number').text()).to.equal(accountNumber)
+  })
+
+  it('should display the enter confirmation page with correct description and amount', () => {
+    expect($(`#payment-description`).text()).to.equal('')
+    expect($(`#amount`).text()).to.equal('')
+  })
+
   it('should display the enter confirmation page with bank statement description', () => {
-    expect($(`#bank-statement-description`).text()).to.equal(`'${description}'`)
+    expect($(`#bank-statement-description`).text()).to.equal('')
   })
 
   it('should display the enter direct debit page with a link to cancel the payment', () => {

--- a/app/confirmation/get.njk
+++ b/app/confirmation/get.njk
@@ -29,7 +29,7 @@
           </tbody>
         </table>
         <div class="panel panel-border-wide bank-statement-message">
-          <p><span class="bold-small" id="bank-statement-description">'{{description}}'</span> will appear on your bank statement</p>
+          <p>We will notify you by email 3 days before each future payment.</p>
         </div>
         <form
           class="form"

--- a/app/confirmation/get.njk
+++ b/app/confirmation/get.njk
@@ -45,13 +45,15 @@
           </div>
         </form>
       </div>
-      <aside class="payment-summary">
-        <div class="payment-summary__inner js-stick-at-top-when-scrolling">
-          <h2 class="heading-medium">Payment summary</h2>
-          <p class="payment-summary__description" id="payment-description">{{description}}</p>
-          <p class="payment-summary__description">Total amount: <span class="payment-summary__amount" id="amount">£{{amount}}</span>
-        </div>
-      </aside>
+      {% if mandateType == 'ONE_OFF' %}
+        <aside class="payment-summary">
+          <div class="payment-summary__inner js-stick-at-top-when-scrolling">
+            <h2 class="heading-medium">Payment summary</h2>
+            <p class="payment-summary__description" id="payment-description">{{description}}</p>
+            <p class="payment-summary__description">Total amount: <span class="payment-summary__amount" id="amount">£{{amount}}</span>
+          </div>
+        </aside>
+      {% endif %}
     </div>
     {% block dd_guarantee_anchor %}
       {% include "app/direct-debit-guarantee/anchor.njk" %}

--- a/app/confirmation/get.njk
+++ b/app/confirmation/get.njk
@@ -28,9 +28,13 @@
           </tr>
           </tbody>
         </table>
+        {% if mandateType == 'ON_DEMAND' %}
         <div class="panel panel-border-wide bank-statement-message">
           <p>We will notify you by email 3 days before each future payment.</p>
         </div>
+        {% else %}
+          <br />
+        {% endif %}
         <form
           class="form"
           method="POST"

--- a/app/setup/get.controller.js
+++ b/app/setup/get.controller.js
@@ -7,11 +7,11 @@ const _ = require('lodash')
 const {getSessionVariable} = require('../../common/config/cookies')
 
 module.exports = (req, res) => {
-  // todo show different page with different params depending on mandate type
   const mandate = res.locals.mandate
   const session = getSessionVariable(req, mandate.externalId)
   const params = {
     mandateExternalId: mandate.externalId,
+    mandateType: mandate.type,
     description: mandate.transaction.description,
     amount: mandate.transaction.amount,
     returnUrl: `/change-payment-method/${mandate.externalId}`,

--- a/app/setup/get.controller.js
+++ b/app/setup/get.controller.js
@@ -8,12 +8,13 @@ const {getSessionVariable} = require('../../common/config/cookies')
 
 module.exports = (req, res) => {
   const mandate = res.locals.mandate
+  const transaction = mandate.transaction || {}
   const session = getSessionVariable(req, mandate.externalId)
   const params = {
     mandateExternalId: mandate.externalId,
     mandateType: mandate.type,
-    description: mandate.transaction.description,
-    amount: mandate.transaction.amount,
+    description: transaction.description,
+    amount: transaction.amount,
     returnUrl: `/change-payment-method/${mandate.externalId}`,
     paymentAction: 'setup',
     service: res.locals.service

--- a/app/setup/get.njk
+++ b/app/setup/get.njk
@@ -18,8 +18,9 @@
             {% include "common/templates/includes/validation-errors.njk" %}
         {% endif %}
         <h1 class="heading-large">Set up a Direct Debit</h1>
-        <p>We’ll take a one-off payment from your bank account</p>
-
+        {% if mandateType == 'ONE_OFF' %}
+          <p>We’ll take a one-off payment from your bank account</p>
+        {% endif %}
         <form class="form" method="POST" action="/setup/{{mandateExternalId}}" class="direct-debit-form" data-validate>
           <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
           {{ form.input(
@@ -101,13 +102,15 @@
             <a class="cancel-link" href="/cancel/{{mandateExternalId}}">Cancel payment</a>
           </div>
         </div>
-      <aside class="payment-summary">
-        <div class="payment-summary__inner js-stick-at-top-when-scrolling">
-          <h2 class="heading-medium">Payment summary</h2>
-          <p class="payment-summary__description" id="payment-description">{{description}}</p>
-          <p class="payment-summary__description">Total amount: <span class="payment-summary__amount" id="amount">£{{amount}}</span>
-        </div>
-      </aside>
+        {% if mandateType == 'ONE_OFF' %}
+          <aside class="payment-summary">
+            <div class="payment-summary__inner js-stick-at-top-when-scrolling">
+              <h2 class="heading-medium">Payment summary</h2>
+              <p class="payment-summary__description" id="payment-description">{{description}}</p>
+              <p class="payment-summary__description">Total amount: <span class="payment-summary__amount" id="amount">£{{amount}}</span>
+            </div>
+          </aside>
+        {% endif %}
     </div>
 
     {% block dd_guarantee_anchor %}

--- a/common/classes/Mandate.class.js
+++ b/common/classes/Mandate.class.js
@@ -1,6 +1,6 @@
 'use strict'
 const Payer = require('./Payer.class')
-const PaymentRequest = require('./PaymentRequest.class')
+const Transaction = require('./Transaction.class')
 
 class Mandate {
   constructor (opts) {
@@ -10,7 +10,7 @@ class Mandate {
     this.gatewayAccountExternalId = opts.gateway_account_external_id
     this.transactionExternalId = opts.transaction_external_id
     this.payer = opts.payer ? new Payer(opts.payer) : null
-    this.transaction = opts.transaction ? new PaymentRequest(opts.transaction) : null
+    this.transaction = opts.transaction ? new Transaction(opts.transaction) : {}
     this.state = opts.state
     this.reference = opts.mandate_reference
     this.type = opts.mandate_type

--- a/common/classes/Mandate.class.js
+++ b/common/classes/Mandate.class.js
@@ -10,7 +10,7 @@ class Mandate {
     this.gatewayAccountExternalId = opts.gateway_account_external_id
     this.transactionExternalId = opts.transaction_external_id
     this.payer = opts.payer ? new Payer(opts.payer) : null
-    this.transaction = opts.transaction ? new Transaction(opts.transaction) : {}
+    this.transaction = opts.transaction ? new Transaction(opts.transaction) : null
     this.state = opts.state
     this.reference = opts.mandate_reference
     this.type = opts.mandate_type

--- a/common/classes/Mandate.class.js
+++ b/common/classes/Mandate.class.js
@@ -11,9 +11,9 @@ class Mandate {
     this.transactionExternalId = opts.transaction_external_id
     this.payer = opts.payer ? new Payer(opts.payer) : null
     this.transaction = opts.transaction ? new PaymentRequest(opts.transaction) : null
-    this.type = opts.type
     this.state = opts.state
     this.reference = opts.mandate_reference
+    this.type = opts.mandate_type
   }
 }
 

--- a/common/classes/Transaction.class.js
+++ b/common/classes/Transaction.class.js
@@ -1,6 +1,6 @@
 'use strict'
 
-class PaymentRequest {
+class Transaction {
   constructor (opts) {
     this.externalId = opts.external_id
     this.amount = penceToPounds(opts.amount)
@@ -14,4 +14,4 @@ const penceToPounds = (pence) => {
   return (parseInt(pence) / 100).toFixed(2)
 }
 
-module.exports = PaymentRequest
+module.exports = Transaction

--- a/common/clients/connector-client.js
+++ b/common/clients/connector-client.js
@@ -8,23 +8,22 @@ const GatewayAccount = require('../../common/classes/GatewayAccount.class')
 
 const service = 'connector'
 const baseUrl = `${CONNECTOR_URL}/v1`
-const headers = {
-}
+const headers = {}
 
 // Exports
 module.exports = {
   retrieveGatewayAccount,
   secure: {
-    retrieveMandateByToken: retrieveMandateByToken,
-    retrievePaymentInformationByExternalId: retrievePaymentInformationByExternalId,
-    deleteToken: deleteToken
+    retrieveMandateByToken,
+    retrievePaymentInformationByExternalId,
+    deleteToken
   },
   payment: {
-    submitDirectDebitDetails: submitDirectDebitDetails,
-    confirmDirectDebitDetails: confirmDirectDebitDetails,
-    cancelPaymentRequest: cancelPaymentRequest,
-    changePaymentMethod: changePaymentMethod,
-    validateBankAccountDetails: validateBankAccountDetails
+    submitDirectDebitDetails,
+    confirmDirectDebitDetails,
+    cancelTransaction,
+    changePaymentMethod,
+    validateBankAccountDetails
   }
 }
 
@@ -114,7 +113,7 @@ function validateBankAccountDetails (accountId, mandateExternalId, body, correla
   })
 }
 
-function cancelPaymentRequest (accountId, mandateExternalId, correlationId) {
+function cancelTransaction (accountId, mandateExternalId, correlationId) {
   return baseClient.post({
     headers,
     baseUrl,
@@ -124,6 +123,7 @@ function cancelPaymentRequest (accountId, mandateExternalId, correlationId) {
     description: `cancel a payment request`
   })
 }
+
 function changePaymentMethod (accountId, mandateExternalId, correlationId) {
   return baseClient.post({
     headers,

--- a/common/middleware/get-mandate/get-mandate.js
+++ b/common/middleware/get-mandate/get-mandate.js
@@ -24,8 +24,8 @@ function middleware (req, res, next) {
   const transactionExternalId = _.get(res, 'locals.transactionExternalId')
 
   connectorClient.secure.retrievePaymentInformationByExternalId(gatewayAccountExternalId, mandateExternalId, transactionExternalId, req.correlationId)
-    .then(mandateInfo => {
-      res.locals.mandate = mandateInfo
+    .then(mandate => {
+      res.locals.mandate = mandate
       next()
     })
     .catch(() => {

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -68,6 +68,7 @@ module.exports = {
       gateway_account_id: 23 || opts.gateway_account_id,
       gateway_account_external_id: opts.gateway_account_external_id || randomExternalId(),
       mandate_reference: opts.mandate_reference || 'buy Silvia a coffee',
+      mandate_type: 'ONE_OFF',
       state: opts.state || 'CREATED',
       payer: opts.payer || null,
       transaction: opts.transaction || {
@@ -77,6 +78,24 @@ module.exports = {
         reference: 'transaction ref',
         state: 'NEW'
       }
+    }
+    return {
+      getPlain: () => {
+        return data
+      }
+    }
+  },
+  validOnDemandMandateResponse: (opts = {}) => {
+    const data = {
+      external_id: opts.external_id || randomExternalId(),
+      return_url: opts.return_url || randomUrl(),
+      gateway_account_id: 23 || opts.gateway_account_id,
+      gateway_account_external_id: opts.gateway_account_external_id || randomExternalId(),
+      mandate_reference: opts.mandate_reference || 'buy Silvia a beer',
+      mandate_type: 'ON_DEMAND',
+      state: opts.state || 'CREATED',
+      payer: opts.payer || null,
+      transaction: null
     }
     return {
       getPlain: () => {

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -1,7 +1,7 @@
 'use strict'
 const Payer = require('../../common/classes/Payer.class')
 const Mandate = require('../../common/classes/Mandate.class')
-const PaymentRequest = require('../../common/classes/PaymentRequest.class')
+const Transaction = require('../../common/classes/Transaction.class')
 const GatewayAccount = require('../../common/classes/GatewayAccount.class')
 const Service = require('../../common/classes/Service.class')
 // Create random values if none provided
@@ -107,7 +107,7 @@ module.exports = {
     return new Payer(data)
   },
 
-  validPaymentRequest: (opts = {}) => {
+  validTransaction: (opts = {}) => {
     const data = {
       external_id: opts.external_id || randomExternalId(),
       return_url: opts.return_url || randomUrl(),
@@ -118,7 +118,7 @@ module.exports = {
       state: opts.state || 'NEW',
       payer: opts.payer || null
     }
-    return new PaymentRequest(data)
+    return new Transaction(data)
   },
   validMandate: (opts = {}) => {
     const data = {


### PR DESCRIPTION
## WHAT

Handle ON_DEMAND payments:
- Changed the `Mandate.type` to be `Mandate.mandate_type` for consistency
- Adapted pages to `ON_DEMAND` payments
- Fixed transactions to work with `ON_DEMAND` payments and fixed the tests

with @georgeracu and @alexbishop1 