### PR TITLE
PP-3838 State enforcer should decide on internal mandate state

### DIFF
--- a/app/cancel/get.controller.tests.js
+++ b/app/cancel/get.controller.tests.js
@@ -23,7 +23,8 @@ const mandateResponse = paymentFixtures.validOneOffMandateResponse({
   return_url: returnUrl,
   state: {
     status: 'started'
-  }
+  },
+  internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
 }).getPlain()
 const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
   gateway_account_external_id: gatewayAccoutExternalId

--- a/app/confirmation/get.controller.tests.js
+++ b/app/confirmation/get.controller.tests.js
@@ -49,7 +49,8 @@ describe('confirmation one-off payment get controller', function () {
       },
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -147,7 +148,8 @@ describe('confirmation on-demand payment get controller', function () {
       gateway_account_external_id: gatewayAccoutExternalId,
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -237,7 +239,8 @@ describe('confirmation get controller with no confirmationDetails', function () 
       },
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -281,7 +284,8 @@ describe('confirmation get controller after successful payment', function () {
   const mandateResponse = paymentFixtures.validOneOffMandateResponse({
     external_id: mandateExternalId,
     gateway_account_external_id: gatewayAccoutExternalId,
-    state: {status: 'pending'}
+    state: {status: 'pending'},
+    internal_state: 'SUBMITTED'
   }).getPlain()
   const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
     gateway_account_external_id: gatewayAccoutExternalId
@@ -329,6 +333,6 @@ describe('confirmation get controller after successful payment', function () {
 
   it('should display the payment completed summary page', () => {
     expect($('form').length).to.equal(0)
-    expect($('.heading-large.pending').length).to.equal(1)
+    expect($('.heading-large.SUBMITTED').length).to.equal(1)
   })
 })

--- a/app/confirmation/post.controller.tests.js
+++ b/app/confirmation/post.controller.tests.js
@@ -21,7 +21,8 @@ const mandateResponse = paymentFixtures.validOneOffMandateResponse({
   gateway_account_external_id: gatewayAccoutExternalId,
   state: {
     status: 'started'
-  }
+  },
+  internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
 }).getPlain()
 const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
   gateway_account_external_id: gatewayAccoutExternalId

--- a/app/setup/get.controller.tests.js
+++ b/app/setup/get.controller.tests.js
@@ -49,7 +49,8 @@ describe('setup get controller', () => {
       return_url: `/change-payment-method/${mandateExternalId}`,
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -122,7 +123,8 @@ describe('setup get controller', () => {
       payer: payer,
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -172,7 +174,8 @@ describe('setup get controller', () => {
       return_url: `/change-payment-method/${mandateExternalId}`,
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId

--- a/app/setup/post.controller.tests.js
+++ b/app/setup/post.controller.tests.js
@@ -72,7 +72,8 @@ describe('setup post controller', () => {
       gateway_account_external_id: gatewayAccoutExternalId,
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -147,7 +148,8 @@ describe('setup post controller', () => {
       gateway_account_external_id: gatewayAccoutExternalId,
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const validateBankAccountResponse = {
       is_valid: true,
@@ -257,7 +259,8 @@ describe('setup post controller', () => {
       gateway_account_external_id: gatewayAccoutExternalId,
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId
@@ -357,7 +360,8 @@ describe('setup post controller', () => {
       gateway_account_external_id: gatewayAccoutExternalId,
       state: {
         status: 'started'
-      }
+      },
+      internal_state: 'AWAITING_DIRECT_DEBIT_DETAILS'
     }).getPlain()
     const gatewayAccountResponse = paymentFixtures.validGatewayAccountResponse({
       gateway_account_external_id: gatewayAccoutExternalId

--- a/common/classes/Mandate.class.js
+++ b/common/classes/Mandate.class.js
@@ -12,6 +12,7 @@ class Mandate {
     this.payer = opts.payer ? new Payer(opts.payer) : null
     this.transaction = opts.transaction ? new Transaction(opts.transaction) : null
     this.state = opts.state
+    this.internalState = opts.internal_state
     this.reference = opts.mandate_reference
     this.type = opts.mandate_type
   }

--- a/test/fixtures/payments-fixtures.js
+++ b/test/fixtures/payments-fixtures.js
@@ -69,7 +69,8 @@ module.exports = {
       gateway_account_external_id: opts.gateway_account_external_id || randomExternalId(),
       mandate_reference: opts.mandate_reference || 'buy Silvia a coffee',
       mandate_type: 'ONE_OFF',
-      state: opts.state || 'CREATED',
+      state: opts.state || 'started',
+      internal_state: opts.internal_state || 'AWAITING_DIRECT_DEBIT_DETAILS',
       payer: opts.payer || null,
       transaction: opts.transaction || {
         external_id: randomExternalId(),
@@ -93,7 +94,8 @@ module.exports = {
       gateway_account_external_id: opts.gateway_account_external_id || randomExternalId(),
       mandate_reference: opts.mandate_reference || 'buy Silvia a beer',
       mandate_type: 'ON_DEMAND',
-      state: opts.state || 'CREATED',
+      state: opts.state || 'started',
+      internal_state: opts.internal_state || 'AWAITING_DIRECT_DEBIT_DETAILS',
       payer: opts.payer || null,
       transaction: null
     }
@@ -146,7 +148,8 @@ module.exports = {
       gateway_account_id: 23 || opts.gateway_account_id,
       gateway_account_external_id: opts.gateway_account_external_id || randomExternalId(),
       mandate_reference: opts.mandate_reference || 'buy Silvia a coffee',
-      state: opts.state || 'CREATED',
+      state: opts.state || 'started',
+      internal_state: opts.internal_state || 'AWAITING_DIRECT_DEBIT_DETAILS',
       type: opts.type || 'ONE_OFF',
       payer: opts.payer || null,
       transaction: opts.transaction || null


### PR DESCRIPTION
## WHAT
 - We want a more fine grained control over mandate states in order to
   show error messages which make sense. We need to decide on the internal
   mandate state rather than the external.