### PR TITLE
PP-3838 Handle mandate expired as failed

### DIFF
--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -38,8 +38,8 @@ const mandateStateToMessageMap = {
     includeReturnUrl: false
   },
   EXPIRED: {
-    heading: 'Your Direct Debit mandate has expired',
-    message: 'Your mandate has not been set up.',
+    heading: 'Your Direct Debit mandate has not been set up',
+    message: 'You might have entered your details incorrectly or your session may have timed out.',
     includeReturnUrl: true
   },
   default: {

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -173,8 +173,8 @@ describe('Mandate state enforcer', () => {
       mandateStateEnforcer.middleware('setup')(req, res, next, response)
       expect(next.called).to.equal(false)
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
-        message: 'Your mandate has not been set up.',
-        heading: 'Your Direct Debit mandate has expired',
+        message: 'You might have entered your details incorrectly or your session may have timed out.',
+        heading: 'Your Direct Debit mandate has not been set up',
         status: 'EXPIRED',
         returnUrl,
         includeReturnUrl: true
@@ -344,8 +344,8 @@ describe('Mandate state enforcer', () => {
       mandateStateEnforcer.middleware('confirmation')(req, res, next, response)
       expect(next.called).to.equal(false)
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
-        message: 'Your mandate has not been set up.',
-        heading: 'Your Direct Debit mandate has expired',
+        message: 'You might have entered your details incorrectly or your session may have timed out.',
+        heading: 'Your Direct Debit mandate has not been set up',
         status: 'EXPIRED',
         returnUrl,
         includeReturnUrl: true


### PR DESCRIPTION
## WHAT
Handling mandate expired as mandate failed, showing the same error message.