### PR TITLE
PP-5269 Handle error validating bank details

### DIFF
--- a/app/setup/post.controller.js
+++ b/app/setup/post.controller.js
@@ -13,70 +13,74 @@ const { renderErrorView } = require('../../common/response')
 const connectorClient = require('../../common/clients/connector-client')
 const { setSessionVariable } = require('../../common/config/cookies')
 
-module.exports = (req, res) => {
-  const mandate = res.locals.mandate
-  const mandateExternalId = mandate.externalId
-  const gatewayAccountExternalId = mandate.gatewayAccountExternalId
-
-  const requestBody = req.body
-  const formValues = {
+const extractFormValues = (requestBody) => {
+  return {
     account_holder_name: lodash.get(requestBody, 'account-holder-name'),
     sort_code: lodash.get(requestBody, 'sort-code'),
     account_number: lodash.get(requestBody, 'account-number'),
     requires_authorisation: lodash.get(requestBody, 'requires-authorisation'),
     email: lodash.get(requestBody, 'email')
   }
+}
 
-  // Normalise request data
+const normaliseFormValues = (formValues) => {
   const normalisedFormValues = lodash.clone(formValues)
   normalisedFormValues.sort_code = normalise.sortCode(formValues.sort_code)
   normalisedFormValues.account_number = normalise.accountNumber(formValues.account_number)
   normalisedFormValues.requires_authorisation =
     (lodash.isNil(formValues.requires_authorisation) || normalise.toBoolean(formValues.requires_authorisation))
-
-  // Validation
-  const payer = new Payer(normalisedFormValues)
-  const payerValidatorErrors = payerValidator(payer)
-  const redirectWithValidationErrors = prepareValidationErrors(res, req, mandateExternalId, formValues)
-  if (lodash.isEmpty(payerValidatorErrors)) {
-    connectorClient.mandate.validateBankAccountDetails(gatewayAccountExternalId, mandateExternalId, {
-      account_number: normalisedFormValues.account_number,
-      sort_code: normalisedFormValues.sort_code
-    }, req.correlationId)
-      .then(bankAccount => {
-        if (bankAccount.is_valid) {
-          normalisedFormValues.bank_name = bankAccount.bank_name
-          connectorClient.mandate.submitDirectDebitDetails(gatewayAccountExternalId, mandateExternalId, normalisedFormValues, req.correlationId)
-            .then(payerExternalId => {
-              logger.info(`[${req.correlationId}] Submitted payment details for request: ${mandateExternalId}, payer: ${payerExternalId}`)
-              req.body.payer_external_id = payerExternalId
-              setSessionVariable(req, `${mandateExternalId}.confirmationDetails`, payer)
-              const url = confirmation.paths.index.replace(':mandateExternalId', mandateExternalId)
-              return res.redirect(303, url)
-            })
-            .catch(() => {
-              renderErrorView(req, res, 'No money has been taken from your account, please try again later.')
-            })
-        } else {
-          redirectWithValidationErrors([
-            {
-              id: 'sort-code',
-              label: 'Sort code'
-            },
-            {
-              id: 'account-number',
-              label: 'Account number'
-            }
-          ])
-        }
-      })
-  } else {
-    redirectWithValidationErrors(payerValidatorErrors)
-  }
+  return normalisedFormValues
 }
-const prepareValidationErrors = (res, req, mandateExternalId, formValues) => (validationErrors) => {
-  setSessionVariable(req, `${mandateExternalId}.formValues`, formValues)
-  setSessionVariable(req, `${mandateExternalId}.validationErrors`, validationErrors)
-  const url = '/setup/:mandateExternalId'.replace(':mandateExternalId', mandateExternalId)
-  return res.redirect(303, url)
+
+module.exports = async function (req, res) {
+  const mandate = res.locals.mandate
+  const mandateExternalId = mandate.externalId
+  const gatewayAccountExternalId = mandate.gatewayAccountExternalId
+  const requestBody = req.body
+
+  try {
+    const formValues = extractFormValues(requestBody)
+    const normalisedPayerDetais = normaliseFormValues(formValues)
+
+    const payer = new Payer(normalisedPayerDetais)
+    let validationErrors = payerValidator(payer)
+
+    if (lodash.isEmpty(validationErrors)) {
+      const bankAccount = await connectorClient.mandate.validateBankAccountDetails(gatewayAccountExternalId, mandateExternalId, {
+        account_number: normalisedPayerDetais.account_number,
+        sort_code: normalisedPayerDetais.sort_code
+      }, req.correlationId)
+
+      if (bankAccount.is_valid) {
+        normalisedPayerDetais.bank_name = bankAccount.bank_name
+        const payerExternalId = await connectorClient.mandate.submitDirectDebitDetails(gatewayAccountExternalId, mandateExternalId, normalisedPayerDetais, req.correlationId)
+        logger.info(`[${req.correlationId}] Submitted payment details for request: ${mandateExternalId}, payer: ${payerExternalId}`)
+        req.body.payer_external_id = payerExternalId
+      } else {
+        validationErrors = [
+          {
+            id: 'sort-code',
+            label: 'Sort code'
+          },
+          {
+            id: 'account-number',
+            label: 'Account number'
+          }
+        ]
+      }
+    }
+
+    if (!lodash.isEmpty(validationErrors)) {
+      setSessionVariable(req, `${mandateExternalId}.formValues`, formValues)
+      setSessionVariable(req, `${mandateExternalId}.validationErrors`, validationErrors)
+      const url = '/setup/:mandateExternalId'.replace(':mandateExternalId', mandateExternalId)
+      return res.redirect(303, url)
+    }
+
+    setSessionVariable(req, `${mandateExternalId}.confirmationDetails`, payer)
+    const url = confirmation.paths.index.replace(':mandateExternalId', mandateExternalId)
+    return res.redirect(303, url)
+  } catch (error) {
+    renderErrorView(req, res, 'No money has been taken from your account, please try again later.')
+  }
 }


### PR DESCRIPTION
When submitting the direct debit setup page we were not handling the
case when there was an error calling connector to verify the bank
details.
Handle this, and improve controller code at the same time.
