### PR TITLE
PP-5265 - Valid account numbers should be 8-10 digits

### DIFF
--- a/common/browsered/field-validation-checks.js
+++ b/common/browsered/field-validation-checks.js
@@ -44,7 +44,7 @@ exports.isSortCode = value => {
 exports.isAccountNumber = value => {
   const trimmedAccountNumber = value.replace(/\s/g, '')
   return {
-    valid: NUMBERS_ONLY.test(trimmedAccountNumber) && (trimmedAccountNumber.length >= 6 && trimmedAccountNumber.length <= 8),
+    valid: NUMBERS_ONLY.test(trimmedAccountNumber) && (trimmedAccountNumber.length >= 8 && trimmedAccountNumber.length <= 10),
     message: errorMessages.accountNumber
   }
 }

--- a/common/browsered/field-validation-checks.test.js
+++ b/common/browsered/field-validation-checks.test.js
@@ -63,21 +63,23 @@ describe('field validation checks', () => {
     })
   })
   describe('isAccountNumber', () => {
-    it('should be valid for a valid account number', () => {
-      expect(isAccountNumber('123 456').valid).to.equal(true)
-      expect(isAccountNumber(' 1 2 3 4 5 6 ').valid).to.equal(true)
+    it('should be true for a valid account number', () => {
+      expect(isAccountNumber('1234 5678').valid).to.equal(true)
+      expect(isAccountNumber(' 1 2 3 4 5 6 7 8').valid).to.equal(true)
       expect(isAccountNumber('12 34 56 78').valid).to.equal(true)
       expect(isAccountNumber('12345678').valid).to.equal(true)
       expect(isAccountNumber('01234567').valid).to.equal(true)
       expect(isAccountNumber(' 12345678 ').valid).to.equal(true)
+      expect(isAccountNumber('123456789').valid).to.equal(true)
+      expect(isAccountNumber('1234567890').valid).to.equal(true)
     })
 
-    it('should not be valid for an invalid account number', () => {
+    it('should be false for an invalid account number', () => {
       expect(isAccountNumber('123-456').valid).to.equal(false)
       expect(isAccountNumber('1-2-3-4-5-6').valid).to.equal(false)
       expect(isAccountNumber('12-34-56').valid).to.equal(false)
-      expect(isAccountNumber('12345').valid).to.equal(false)
-      expect(isAccountNumber('123456789').valid).to.equal(false)
+      expect(isAccountNumber('123456').valid).to.equal(false)
+      expect(isAccountNumber('12345678910').valid).to.equal(false)
       expect(isAccountNumber('1234a56789').valid).to.equal(false)
     })
     it('should display an error message for an invalid account number', () => {


### PR DESCRIPTION
Not sure why this was set to 6-8
