### PR TITLE
PP-5265 fix valid account number boundaries revert

### DIFF
--- a/app/setup/get.njk
+++ b/app/setup/get.njk
@@ -86,7 +86,7 @@
                 classes: "govuk-label--s"
               },
               hint: {
-                text: "Must be between 8 and 10 digits long"
+                text: "Must be between 6 and 8 digits long"
               },
               value: formValues.account_number,
               classes: "govuk-!-width-one-third",

--- a/common/browsered/field-validation-checks.js
+++ b/common/browsered/field-validation-checks.js
@@ -44,7 +44,7 @@ exports.isSortCode = value => {
 exports.isAccountNumber = value => {
   const trimmedAccountNumber = value.replace(/\s/g, '')
   return {
-    valid: NUMBERS_ONLY.test(trimmedAccountNumber) && (trimmedAccountNumber.length >= 8 && trimmedAccountNumber.length <= 10),
+    valid: NUMBERS_ONLY.test(trimmedAccountNumber) && (trimmedAccountNumber.length >= 6 && trimmedAccountNumber.length <= 8),
     message: errorMessages.accountNumber
   }
 }

--- a/common/browsered/field-validation-checks.js
+++ b/common/browsered/field-validation-checks.js
@@ -10,7 +10,7 @@ const errorMessages = {
   validEmail: 'Please use a valid email address',
   checked: 'Please choose an option',
   sortCode: 'Enter a real sort code with 6 digits',
-  accountNumber: 'Enter a real account number between 8 and 10 digits long'
+  accountNumber: 'Enter a real account number between 6 and 8 digits long'
 }
 
 // Exports

--- a/common/browsered/field-validation-checks.test.js
+++ b/common/browsered/field-validation-checks.test.js
@@ -81,7 +81,7 @@ describe('field validation checks', () => {
       expect(isAccountNumber('1234a56789').valid).to.equal(false)
     })
     it('should display an error message for an invalid account number', () => {
-      expect(isAccountNumber('invalid').message).to.equal('Enter a real account number between 8 and 10 digits long')
+      expect(isAccountNumber('invalid').message).to.equal('Enter a real account number between 6 and 8 digits long')
     })
   })
   describe('isChecked', () => {

--- a/common/browsered/field-validation-checks.test.js
+++ b/common/browsered/field-validation-checks.test.js
@@ -63,23 +63,21 @@ describe('field validation checks', () => {
     })
   })
   describe('isAccountNumber', () => {
-    it('should be true for a valid account number', () => {
-      expect(isAccountNumber('1234 5678').valid).to.equal(true)
-      expect(isAccountNumber(' 1 2 3 4 5 6 7 8').valid).to.equal(true)
+    it('should be valid for a valid account number', () => {
+      expect(isAccountNumber('123 456').valid).to.equal(true)
+      expect(isAccountNumber(' 1 2 3 4 5 6 ').valid).to.equal(true)
       expect(isAccountNumber('12 34 56 78').valid).to.equal(true)
       expect(isAccountNumber('12345678').valid).to.equal(true)
       expect(isAccountNumber('01234567').valid).to.equal(true)
       expect(isAccountNumber(' 12345678 ').valid).to.equal(true)
-      expect(isAccountNumber('123456789').valid).to.equal(true)
-      expect(isAccountNumber('1234567890').valid).to.equal(true)
     })
 
-    it('should be false for an invalid account number', () => {
+    it('should not be valid for an invalid account number', () => {
       expect(isAccountNumber('123-456').valid).to.equal(false)
       expect(isAccountNumber('1-2-3-4-5-6').valid).to.equal(false)
       expect(isAccountNumber('12-34-56').valid).to.equal(false)
-      expect(isAccountNumber('123456').valid).to.equal(false)
-      expect(isAccountNumber('12345678910').valid).to.equal(false)
+      expect(isAccountNumber('12345').valid).to.equal(false)
+      expect(isAccountNumber('123456789').valid).to.equal(false)
       expect(isAccountNumber('1234a56789').valid).to.equal(false)
     })
     it('should display an error message for an invalid account number', () => {


### PR DESCRIPTION
Account numbers are in fact between 6 and 8 digits long