### PR TITLE
Use runAppE2E to run end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         }
       }
     }
-    stage('Direct-Debit End-to-End') {
+    stage('End-to-End tests') {
       when {
         anyOf {
           branch 'master'
@@ -43,7 +43,7 @@ pipeline {
         }
       }
       steps {
-        runDirectDebitE2E("directdebit-frontend")
+        runAppE2E("directdebit-frontend", "directdebit")
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
Let's deprecate the run{test}E2E groovy routines and use runAppE2E everywhere