### PR TITLE
PP-5534 Update internal states

### DIFF
--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -11,33 +11,22 @@ const pageToValidMandateStateMap = {
   'cancel': ['AWAITING_DIRECT_DEBIT_DETAILS']
 }
 
+const inProgressMessage = {
+  heading: 'Your Direct Debit mandate is being processed',
+  message: 'Check your confirmation email for details of your mandate.',
+  includeReturnUrl: false
+}
+
 const mandateStateToMessageMap = {
-  USER_CANCEL_NOT_ELIGIBLE: {
-    heading: 'You have cancelled the Direct Debit mandate setup',
-    message: 'Your mandate has not been set up.',
-    includeReturnUrl: true
-  },
-  SUBMITTED: {
-    heading: 'Your Direct Debit mandate is being processed',
-    message: 'Check your confirmation email for details of your mandate.',
-    includeReturnUrl: false
-  },
-  PENDING: {
-    heading: 'Your Direct Debit mandate is being processed',
-    message: 'Check your confirmation email for details of your mandate.',
-    includeReturnUrl: false
-  },
+  SUBMITTED_TO_PROVIDER: inProgressMessage,
+  SUBMITTED_TO_BANK: inProgressMessage,
+  ACTIVE: inProgressMessage,
   FAILED: {
     heading: 'Your Direct Debit mandate has not been set up',
     message: 'You might have entered your details incorrectly or your session may have timed out.',
     includeReturnUrl: true
   },
-  ACTIVE: {
-    heading: 'Your Direct Debit mandate has been set up',
-    message: 'We have sent you a confirmation email with your mandate details.',
-    includeReturnUrl: false
-  },
-  EXPIRED: {
+  USER_SETUP_EXPIRED: {
     heading: 'Your Direct Debit mandate has not been set up',
     message: 'You might have entered your details incorrectly or your session may have timed out.',
     includeReturnUrl: true

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -31,6 +31,11 @@ const mandateStateToMessageMap = {
     message: 'You might have entered your details incorrectly or your session may have timed out.',
     includeReturnUrl: true
   },
+  USER_SETUP_CANCELLED: {
+    heading: 'You have cancelled the Direct Debit mandate setup',
+    message: 'Your mandate has not been set up.',
+    includeReturnUrl: true
+  },
   default: {
     heading: 'Sorry, we are experiencing technical problems',
     message: 'Your session may have timed out.',

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -136,6 +136,28 @@ describe('Mandate state enforcer', () => {
         includeReturnUrl: true
       })
     })
+    it('should render error page for mandate status of "USER_SETUP_CANCELLED" on page "setup"', () => {
+      const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
+        locals: {
+          mandate: {
+            returnUrl: returnUrl,
+            state: {
+              status: 'cancelled'
+            },
+            internalState: 'USER_SETUP_CANCELLED'
+          }
+        }
+      })
+      mandateStateEnforcer.middleware('setup')(req, res, next, response)
+      expect(next.called).to.equal(false)
+      sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
+        message: 'Your mandate has not been set up.',
+	heading: 'You have cancelled the Direct Debit mandate setup',
+        status: 'USER_SETUP_CANCELLED',
+        returnUrl,
+        includeReturnUrl: true
+      })
+    })
     it('should render error page for mandate status of "USER_SETUP_EXPIRED" on page "setup"', () => {
       const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
         locals: {
@@ -281,6 +303,28 @@ describe('Mandate state enforcer', () => {
         message: 'You might have entered your details incorrectly or your session may have timed out.',
         heading: 'Your Direct Debit mandate has not been set up',
         status: 'FAILED',
+        returnUrl,
+        includeReturnUrl: true
+      })
+    })
+    it('should render error page for mandate status of "USER_SETUP_CANCELLED"', () => {
+      const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
+        locals: {
+          mandate: {
+            returnUrl: returnUrl,
+            state: {
+              status: 'cancelled'
+            },
+            internalState: 'USER_SETUP_CANCELLED'
+          }
+        }
+      })
+      mandateStateEnforcer.middleware('confirmation')(req, res, next, response)
+      expect(next.called).to.equal(false)
+      sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
+        message: 'Your mandate has not been set up.',
+        heading: 'You have cancelled the Direct Debit mandate setup',
+        status: 'USER_SETUP_CANCELLED',
         returnUrl,
         includeReturnUrl: true
       })

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.tests.js
@@ -48,7 +48,7 @@ describe('Mandate state enforcer', () => {
 
       expect(next.called).to.equal(true)
     })
-    it('should render error page for mandate status of "SUBMITTED" on page "setup"', () => {
+    it('should render error page for mandate status of "SUBMITTED_TO_BANK" on page "setup"', () => {
       const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
         locals: {
           mandate: {
@@ -56,7 +56,7 @@ describe('Mandate state enforcer', () => {
             state: {
               status: 'pending'
             },
-            internalState: 'SUBMITTED'
+            internalState: 'SUBMITTED_TO_BANK'
           }
         }
       })
@@ -65,12 +65,12 @@ describe('Mandate state enforcer', () => {
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'Check your confirmation email for details of your mandate.',
         heading: 'Your Direct Debit mandate is being processed',
-        status: 'SUBMITTED',
+        status: 'SUBMITTED_TO_BANK',
         returnUrl,
         includeReturnUrl: false
       })
     })
-    it('should render error page for mandate status of "PENDING" on page "setup"', () => {
+    it('should render error page for mandate status of "SUBMITTED_TO_PROVIDER" on page "setup"', () => {
       const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
         locals: {
           mandate: {
@@ -78,7 +78,7 @@ describe('Mandate state enforcer', () => {
             state: {
               status: 'pending'
             },
-            internalState: 'PENDING'
+            internalState: 'SUBMITTED_TO_PROVIDER'
           }
         }
       })
@@ -87,7 +87,7 @@ describe('Mandate state enforcer', () => {
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'Check your confirmation email for details of your mandate.',
         heading: 'Your Direct Debit mandate is being processed',
-        status: 'PENDING',
+        status: 'SUBMITTED_TO_PROVIDER',
         returnUrl,
         includeReturnUrl: false
       })
@@ -107,8 +107,8 @@ describe('Mandate state enforcer', () => {
       mandateStateEnforcer.middleware('setup')(req, res, next, response)
       expect(next.called).to.equal(false)
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
-        message: 'We have sent you a confirmation email with your mandate details.',
-        heading: 'Your Direct Debit mandate has been set up',
+        message: 'Check your confirmation email for details of your mandate.',
+        heading: 'Your Direct Debit mandate is being processed',
         status: 'ACTIVE',
         returnUrl,
         includeReturnUrl: false
@@ -136,7 +136,7 @@ describe('Mandate state enforcer', () => {
         includeReturnUrl: true
       })
     })
-    it('should render error page for mandate status of "USER_CANCEL_NOT_ELIGIBLE" on page "setup"', () => {
+    it('should render error page for mandate status of "USER_SETUP_EXPIRED" on page "setup"', () => {
       const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
         locals: {
           mandate: {
@@ -144,29 +144,7 @@ describe('Mandate state enforcer', () => {
             state: {
               status: 'cancelled'
             },
-            internalState: 'USER_CANCEL_NOT_ELIGIBLE'
-          }
-        }
-      })
-      mandateStateEnforcer.middleware('setup')(req, res, next, response)
-      expect(next.called).to.equal(false)
-      sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
-        message: 'Your mandate has not been set up.',
-        heading: 'You have cancelled the Direct Debit mandate setup',
-        status: 'USER_CANCEL_NOT_ELIGIBLE',
-        returnUrl,
-        includeReturnUrl: true
-      })
-    })
-    it('should render error page for mandate status of "EXPIRED" on page "setup"', () => {
-      const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
-        locals: {
-          mandate: {
-            returnUrl: returnUrl,
-            state: {
-              status: 'cancelled'
-            },
-            internalState: 'EXPIRED'
+            internalState: 'USER_SETUP_EXPIRED'
           }
         }
       })
@@ -175,7 +153,7 @@ describe('Mandate state enforcer', () => {
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'You might have entered your details incorrectly or your session may have timed out.',
         heading: 'Your Direct Debit mandate has not been set up',
-        status: 'EXPIRED',
+        status: 'USER_SETUP_EXPIRED',
         returnUrl,
         includeReturnUrl: true
       })
@@ -219,7 +197,7 @@ describe('Mandate state enforcer', () => {
 
       expect(next.called).to.equal(true)
     })
-    it('should render error page for mandate status of "SUBMITTED"', () => {
+    it('should render error page for mandate status of "SUBMITTED_TO_BANK"', () => {
       const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
         locals: {
           mandate: {
@@ -227,7 +205,7 @@ describe('Mandate state enforcer', () => {
             state: {
               status: 'pending'
             },
-            internalState: 'SUBMITTED'
+            internalState: 'SUBMITTED_TO_BANK'
           }
         }
       })
@@ -236,12 +214,12 @@ describe('Mandate state enforcer', () => {
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'Check your confirmation email for details of your mandate.',
         heading: 'Your Direct Debit mandate is being processed',
-        status: 'SUBMITTED',
+        status: 'SUBMITTED_TO_BANK',
         returnUrl,
         includeReturnUrl: false
       })
     })
-    it('should render error page for mandate status of "PENDING"', () => {
+    it('should render error page for mandate status of "SUBMITTED_TO_PROVIDER"', () => {
       const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
         locals: {
           mandate: {
@@ -249,7 +227,7 @@ describe('Mandate state enforcer', () => {
             state: {
               status: 'pending'
             },
-            internalState: 'PENDING'
+            internalState: 'SUBMITTED_TO_PROVIDER'
           }
         }
       })
@@ -258,7 +236,7 @@ describe('Mandate state enforcer', () => {
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'Check your confirmation email for details of your mandate.',
         heading: 'Your Direct Debit mandate is being processed',
-        status: 'PENDING',
+        status: 'SUBMITTED_TO_PROVIDER',
         returnUrl,
         includeReturnUrl: false
       })
@@ -278,8 +256,8 @@ describe('Mandate state enforcer', () => {
       mandateStateEnforcer.middleware('confirmation')(req, res, next, response)
       expect(next.called).to.equal(false)
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
-        message: 'We have sent you a confirmation email with your mandate details.',
-        heading: 'Your Direct Debit mandate has been set up',
+        message: 'Check your confirmation email for details of your mandate.',
+        heading: 'Your Direct Debit mandate is being processed',
         status: 'ACTIVE',
         returnUrl,
         includeReturnUrl: false
@@ -307,7 +285,7 @@ describe('Mandate state enforcer', () => {
         includeReturnUrl: true
       })
     })
-    it('should render error page for mandate status of "USER_CANCEL_NOT_ELIGIBLE"', () => {
+    it('should render error page for mandate status of "USER_SETUP_EXPIRED"', () => {
       const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
         locals: {
           mandate: {
@@ -315,29 +293,7 @@ describe('Mandate state enforcer', () => {
             state: {
               status: 'cancelled'
             },
-            internalState: 'USER_CANCEL_NOT_ELIGIBLE'
-          }
-        }
-      })
-      mandateStateEnforcer.middleware('confirmation')(req, res, next, response)
-      expect(next.called).to.equal(false)
-      sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
-        message: 'Your mandate has not been set up.',
-        heading: 'You have cancelled the Direct Debit mandate setup',
-        status: 'USER_CANCEL_NOT_ELIGIBLE',
-        returnUrl,
-        includeReturnUrl: true
-      })
-    })
-    it('should render error page for mandate status of "EXPIRED"', () => {
-      const { req, res, next, response, mandateStateEnforcer } = setupFixtures({
-        locals: {
-          mandate: {
-            returnUrl: returnUrl,
-            state: {
-              status: 'cancelled'
-            },
-            internalState: 'EXPIRED'
+            internalState: 'USER_SETUP_EXPIRED'
           }
         }
       })
@@ -346,7 +302,7 @@ describe('Mandate state enforcer', () => {
       sinon.assert.calledWith(response, req, res, 'common/templates/mandate_state_page', {
         message: 'You might have entered your details incorrectly or your session may have timed out.',
         heading: 'Your Direct Debit mandate has not been set up',
-        status: 'EXPIRED',
+        status: 'USER_SETUP_EXPIRED',
         returnUrl,
         includeReturnUrl: true
       })


### PR DESCRIPTION
Replace `EXPIRED` with `USER_SETUP_EXPIRED`
Remove conditions and tests for `PENDING` and `USER_CANCEL_NOT_ELIGBLE` as
the internal states no longer exists.
Renamed `SUBMITTED` to `SUBMITTED_TO_PROVIDER` and added new internal
state of `SUBMITTED_TO_BANK` with tests.
Align heading and message for `ACTIVE` with submitted statuses.