### PR TITLE
PP - 5533 fix field validation bugs

### DIFF
--- a/common/assets/sass/modules/_button.scss
+++ b/common/assets/sass/modules/_button.scss
@@ -1,0 +1,20 @@
+// Because we have JS validating on blur there is
+// an edge case (PP-5533) where when clicking the
+// submit button when you‘re focused on a errored
+// field causes the page to jump up and then the
+// click event misses the button.
+// So we can fix this by making the button invisibly
+// bigger when it becomes active.
+
+.govuk-button {
+  position: relative;
+
+  &:active:before {
+    content: "";
+    position: absolute;
+    top: -2rem;
+    bottom: -2rem;
+    left: -2rem;
+    right: -2rem;
+  }
+}

--- a/common/browsered/field-validation.js
+++ b/common/browsered/field-validation.js
@@ -40,11 +40,11 @@ function initFieldValidate (e) {
 }
 
 function initValidation (e) {
-  let form = e.target
+  const form = e.target
   e.preventDefault()
   clearPreviousErrors()
 
-  let validatedFields = findFields(form)
+  const validatedFields = findFields(form)
     .map(field => validateField(form, field))
 
   if (every(validatedFields, 'valid')) {
@@ -87,7 +87,7 @@ function findFields (form) {
 
 function validateField (form, field) {
   let result = {}
-  let validationTypes = field.getAttribute('data-validate').split(' ')
+  const validationTypes = field.getAttribute('data-validate').split(' ')
 
   validationTypes.forEach(validationType => {
     switch (validationType) {
@@ -121,7 +121,7 @@ function applyErrorMessaging (form, field, result) {
     field.classList.add(INPUT_ERROR_CLASSNAME)
   }
   // Modify the form group
-  let formGroup = field.closest(FORM_GROUP)
+  const formGroup = field.closest(FORM_GROUP)
   if (!formGroup.classList.contains(FORM_GROUP_ERROR_CLASSNAME)) {
     formGroup.classList.add(FORM_GROUP_ERROR_CLASSNAME)
     const errorLegendElement = formGroup.querySelector('legend')

--- a/common/browsered/field-validation.js
+++ b/common/browsered/field-validation.js
@@ -34,7 +34,7 @@ exports.enableFieldValidation = function () {
 }
 
 function initFieldValidate (e) {
-  const { target, form } = e
+  const { target, target: { form } } = e
   clearPreviousError(target)
   validateField(form, target)
 }

--- a/common/browsered/field-validation.js
+++ b/common/browsered/field-validation.js
@@ -126,9 +126,9 @@ function applyErrorMessaging (form, field, result) {
     formGroup.classList.add(FORM_GROUP_ERROR_CLASSNAME)
     const errorLegendElement = formGroup.querySelector('legend')
     if (errorLegendElement === null) {
-      const errorElement = document.querySelector('label[for="' + field.name + '"]')
-      const errorLabel = result.message || errorElement.getAttribute('data-error-label')
-      errorElement.appendChild(generateErrorMessageElement(errorLabel))
+      const errorLabelElement = document.querySelector('label[for="' + field.name + '"]')
+      const errorLabelText = result.message || errorLabelElement.getAttribute('data-error-label')
+      field.parentNode.insertBefore(generateErrorMessageElement(errorLabelText), field)
     } else {
       errorLegendElement.appendChild(generateErrorMessageElement(errorLegendElement.getAttribute('data-error-label')))
     }


### PR DESCRIPTION
Because we have JS validating on blur there is an edge case (read more at PP-5533) where when clicking the submit button when you‘re focused on a errored field causes the page to jump up and then the click event misses the button.
So we can fix this by making the button invisibly bigger when it becomes active.
