### PR TITLE
PP-5532 Move Email to last line on mandate confirmation page

### DIFF
--- a/app/confirmation/get.njk
+++ b/app/confirmation/get.njk
@@ -36,17 +36,6 @@
                   }
                 }
               ],
-              [
-                {
-                  text: "Email"
-                },
-                {
-                  text: accountEmailAddress,
-                  attributes: {
-                    id: "account-email-address"
-                  }
-                }
-              ],
 	      [
                 {
                   text: "Sort code:"
@@ -66,6 +55,17 @@
                   text: accountNumber,
                   attributes: {
                     id: "account-number"
+                  }
+                }
+              ],
+              [
+                {
+                  text: "Email:"
+                },
+                {
+                  text: accountEmailAddress,
+                  attributes: {
+                    id: "account-email-address"
                   }
                 }
               ]


### PR DESCRIPTION
@stephencdaly good suggestion and Conor agrees, this moves email to the last row (and adds a missing `:`).
