### PR TITLE
PP-5613 Add filename to logger

### DIFF
--- a/app/setup/post.controller.js
+++ b/app/setup/post.controller.js
@@ -4,7 +4,7 @@
 const lodash = require('lodash')
 
 // Local dependencies
-const logger = require('../utils/logger')
+const logger = require('../utils/logger')(__filename)
 const confirmation = require('./../confirmation')
 const normalise = require('../../common/utils/normalise')
 const Payer = require('../../common/classes/Payer.class')

--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -13,4 +13,6 @@ const logger = createLogger({
   ]
 })
 
-module.exports = logger
+module.exports = ( loggerName ) => {
+  return logger.child({ logger: loggerName })
+}

--- a/common/clients/base-client/base-client.js
+++ b/common/clients/base-client/base-client.js
@@ -4,7 +4,7 @@
 const request = require('requestretry')
 const wrapper = require('./wrapper')
 
-const logger = require('../../../app/utils/logger')
+const logger = require('../../../app/utils/logger')(__filename)
 
 // Create request.defaults config
 const requestOptions = {

--- a/common/middleware/check-secure-cookie/check-secure-cookie.js
+++ b/common/middleware/check-secure-cookie/check-secure-cookie.js
@@ -5,7 +5,7 @@ const _ = require('lodash')
 const { EXTERNAL_ID } = require('@govuk-pay/pay-js-commons').loggingKeys
 
 // local dependencies
-const logger = require('../../../app/utils/logger')
+const logger = require('../../../app/utils/logger')(__filename)
 const { renderErrorView } = require('../../response')
 const { getSessionVariable } = require('../../config/cookies')
 

--- a/common/middleware/csrf/csrf.js
+++ b/common/middleware/csrf/csrf.js
@@ -4,7 +4,7 @@
 const csrf = require('csrf')
 
 // Local Dependencies
-const logger = require('../../../app/utils/logger')
+const logger = require('../../../app/utils/logger')(__filename)
 const { renderErrorView } = require('../../response')
 const { getSessionVariable, setSessionVariable } = require('../../config/cookies')
 // Assignments and Variables

--- a/common/middleware/get-gateway-account/get-gateway-account.js
+++ b/common/middleware/get-gateway-account/get-gateway-account.js
@@ -5,7 +5,7 @@ const _ = require('lodash')
 const { Cache } = require('memory-cache')
 
 // local dependencies
-const logger = require('../../../app/utils/logger')
+const logger = require('../../../app/utils/logger')(__filename)
 const { renderErrorView } = require('../../response')
 const connectorClient = require('../../clients/connector-client')
 

--- a/common/middleware/get-mandate/get-mandate.js
+++ b/common/middleware/get-mandate/get-mandate.js
@@ -4,7 +4,7 @@
 const _ = require('lodash')
 
 // local dependencies
-const logger = require('../../../app/utils/logger')
+const logger = require('../../../app/utils/logger')(__filename)
 const { renderErrorView } = require('../../response')
 const connectorClient = require('../../clients/connector-client')
 

--- a/common/middleware/get-service/get-service.js
+++ b/common/middleware/get-service/get-service.js
@@ -5,7 +5,7 @@ const _ = require('lodash')
 const { Cache } = require('memory-cache')
 
 // local dependencies
-const logger = require('../../../app/utils/logger')
+const logger = require('../../../app/utils/logger')(__filename)
 const { renderErrorView } = require('../../response')
 const adminusersClient = require('../../clients/adminusers-client')
 

--- a/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
+++ b/common/middleware/mandate-state-enforcer/mandate-state-enforcer.js
@@ -2,7 +2,7 @@
 const _ = require('lodash')
 
 // local dependencies
-const logger = require('../../../app/utils/logger')
+const logger = require('../../../app/utils/logger')(__filename)
 const { response } = require('../../response')
 
 const pageToValidMandateStateMap = {

--- a/common/response.js
+++ b/common/response.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const logger = require('../app/utils/logger')
+const logger = require('../app/utils/logger')(__filename)
 const ERROR_MESSAGE = 'There is a problem with the payments platform'
 
 function response (req, res, template, data) {

--- a/common/utils/request-logger.js
+++ b/common/utils/request-logger.js
@@ -1,4 +1,4 @@
-const logger = require('../../app/utils/logger')
+const logger = require('../../app/utils/logger')(__filename)
 
 module.exports = {
   logRequestStart: context => {

--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ const router = require('./app/router')
 const noCache = require('./common/utils/no-cache')
 const correlationHeader = require('./common/middleware/correlation-header/correlation-header')
 const cookieConfig = require('./common/config/cookies')
-const logger = require('./app/utils/logger')
+const logger = require('./app/utils/logger')(__filename)
 
 // Global constants
 const unconfiguredApp = express()

--- a/start.js
+++ b/start.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const fs = require('fs')
-const logger = require('./app/utils/logger')
+const logger = require('./app/utils/logger')(__filename)
 const throng = require('throng')
 const server = require('./server')
 const pidFile = path.join(__dirname, '/.start.pid')


### PR DESCRIPTION
Use Winston's child function and override the logger attribute with the name
of the file in each place we're using a logger. This will help us track down errors to the file
that they're being thrown in (like we do with Java apps).

How to test
Check the log output in the tests to check that `logger` corresponds to the correct file.