### PR TITLE
PP-5511: Log timestamp according to the GDS standard

### DIFF
--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -1,11 +1,13 @@
 const { createLogger, format, transports } = require('winston')
-const { timestamp, json, label, splat, prettyPrint } = format
+const { json, label, splat, prettyPrint } = format
+const timestampFormat = require('./timestamp-format')
+
 const logger = createLogger({
   format: format.combine(
     splat(),
     label({ label: 'direct-debit-frontend-sl-beta' }),
     prettyPrint(),
-    timestamp(),
+    timestampFormat(),
     json()
   ),
   transports: [
@@ -13,6 +15,6 @@ const logger = createLogger({
   ]
 })
 
-module.exports = ( loggerName ) => {
+module.exports = (loggerName) => {
   return logger.child({ logger: loggerName })
 }

--- a/app/utils/timestamp-format.js
+++ b/app/utils/timestamp-format.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const { format } = require('winston')
+
+module.exports = format((info) => {
+  info['@timestamp'] = new Date().toISOString()
+  return info
+})


### PR DESCRIPTION
Timestamps should be logged as '@timestamp' (see https://gds-way.cloudapps.digital/manuals/logging.html#content).

@RoryMalcolm @oswaldquek 