### PR TITLE
PP-5735 Change 'label' key in logs to 'container'

### DIFF
--- a/app/utils/logger-format.js
+++ b/app/utils/logger-format.js
@@ -2,9 +2,10 @@
 
 const { format } = require('winston')
 
-module.exports = format((info) => {
+module.exports = format((info, opts) => {
   info['@timestamp'] = new Date().toISOString()
   info['@version'] = 1
+  info['container'] = opts.container
   info.level = info.level.toUpperCase()
   return info
 })

--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -1,13 +1,12 @@
 const { createLogger, format, transports } = require('winston')
-const { json, label, splat, prettyPrint } = format
+const { json, splat, prettyPrint } = format
 const loggerFormat = require('./logger-format')
 
 const logger = createLogger({
   format: format.combine(
     splat(),
-    label({ label: 'directdebit-frontend' }),
     prettyPrint(),
-    loggerFormat(),
+    loggerFormat({ container: 'directdebit-frontend' }),
     json()
   ),
   transports: [


### PR DESCRIPTION
Changing as this is the term used in current splunk searches.
