### PR TITLE
PP-5726 Remove sentry-test endpoint

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -9,7 +9,6 @@ const cancel = require('./cancel')
 const directDebitGuarantee = require('./direct-debit-guarantee')
 const confirmation = require('./confirmation')
 const changePaymentMethod = require('./change-payment-method')
-const { renderErrorView } = require('../common/response')
 
 // Export
 module.exports.bind = app => {
@@ -21,13 +20,6 @@ module.exports.bind = app => {
   app.use(directDebitGuarantee.router)
   app.use(confirmation.router)
   app.use(changePaymentMethod.router)
-  app.get('/sentry-test-default', (req, res) => {
-    throw new Error('My first Sentry error!')
-  })
-
-  app.get('/sentry-test', (req, res) => {
-    renderErrorView(req, res, 'ERROR MESSAGE', 500, new Error('throwing a new error'))
-  })
 
   // route to gov.uk 404 page
   // this has to be the last route registered otherwise it will redirect other routes


### PR DESCRIPTION
This was only a temporary end-point to make testing our Sentry
integration easier. Now that we're confident it works, it is being
removed.