### PR TITLE
PP-5809: Only send logs at ERROR level to Sentry

### DIFF
--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -1,6 +1,7 @@
 const { createLogger, format, transports } = require('winston')
 const { json, splat, prettyPrint } = format
 const { govUkPayLoggingFormat } = require('@govuk-pay/pay-js-commons').logging
+const WinstonSentryTransport = require('./winstonSentryTransport')
 
 const logger = createLogger({
   format: format.combine(
@@ -13,6 +14,11 @@ const logger = createLogger({
     new transports.Console()
   ]
 })
+
+const sentryTransport = new WinstonSentryTransport({
+  level: 'error'
+})
+logger.add(sentryTransport)
 
 module.exports = (loggerName) => {
   return logger.child({ logger_name: loggerName })

--- a/app/utils/winstonSentryTransport.js
+++ b/app/utils/winstonSentryTransport.js
@@ -1,0 +1,15 @@
+const TransportStream = require('winston-transport')
+const Sentry = require('@sentry/node')
+
+class WinstonSentryTransport extends TransportStream {
+  log (info, callback) {
+    setImmediate(() => {
+      this.emit('logged', info)
+    })
+
+    Sentry.captureException(new Error(JSON.stringify(info)))
+    callback()
+  }
+}
+
+module.exports = WinstonSentryTransport

--- a/common/response.js
+++ b/common/response.js
@@ -1,6 +1,4 @@
 'use strict'
-const Sentry = require('@sentry/node')
-
 const logger = require('../app/utils/logger')(__filename)
 const ERROR_MESSAGE = 'There is a problem with the payments platform'
 
@@ -9,14 +7,6 @@ function response (req, res, template, data) {
 }
 
 function renderErrorView (req, res, msg = ERROR_MESSAGE, status = 500, err) {
-  if (status >= 500) {
-    if (err) {
-      Sentry.captureException(err)
-    } else {
-      Sentry.captureMessage(msg)
-    }
-  }
-
   logger.error(`[${req.correlationId}] ${status} An error has occurred. Rendering error view -`, { errorMessage: msg })
   res.setHeader('Content-Type', 'text/html')
   res.status(status)


### PR DESCRIPTION
Currently dd-frontend sends all logs to Sentry; we only want it to send logs at
ERROR level.
