### PR TITLE
BAU Fix request logging

### DIFF
--- a/common/middleware/logging_middleware.js
+++ b/common/middleware/logging_middleware.js
@@ -1,9 +1,10 @@
 const morgan = require('morgan')
-const { requestLogFormat } = require('@govuk-pay/pay-js-commons').logging
 const logger = require('../../app/utils/logger')(__filename)
+const { CORRELATION_HEADER } = require('../config')
+const { format } = require('@govuk-pay/pay-js-commons').logging.requestLogFormat(CORRELATION_HEADER)
 
 module.exports = function () {
-  return morgan(requestLogFormat, {
+  return morgan(format, {
     stream: {
       write: message => {
         logger.info('Request received', JSON.parse(message))


### PR DESCRIPTION
Logging middleware was throwing an error when attempting to log, as
`logging.requestLogFormat` in pay-js-commons had been modified, but
the consuming module hadn't been updated to work with the changes.