### PR TITLE
PP-6037: Add libconf appmetrics build dependency in Travis build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: node_js
 node_js:
   - 12.2.0
 
+addons:
+  apt:
+    packages:
+      # Ubuntu 16+ does not install this dependency by default, so we need to install it ourselves
+      - libgconf-2-4
+
 cache:
   # Caches $HOME/.npm when npm ci is default script command
   # Caches node_modules in all other cases


### PR DESCRIPTION
## WHAT
Appmetrics package requires libconf to be present in the build environment.
