### PR TITLE
PP-6085: Add env-map buildpack

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -1,0 +1,4 @@
+env_vars:
+  CONNECTOR_URL: '."user-provided"[0].credentials.directdebit_connector_url'
+  ADMINUSERS_URL: '."user-provided"[0].credentials.adminusers_url'
+  PUBLICAUTH_URL: '."user-provided"[0].credentials.publicauth_url'

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,12 +2,15 @@
 applications:
 - name: directdebit-frontend
   buildpacks:
-  - nodejs_buildpack
+    - https://github.com/alphagov/env-map-buildpack.git#v1
+    - nodejs_buildpack
   health-check-type: http
   health-check-http-endpoint: '/healthcheck'
   health-check-invocation-timeout: 5
   memory: ((memory))
   disk_quota: ((disk_quota))
+  services:
+    - app-catalog
   command: npm start
   env:
     NODE_ENV: production
@@ -15,10 +18,5 @@ applications:
     COOKIE_MAX_AGE: '10800000'
     ANALYTICS_TRACKING_ID: ((direct_debit_frontend_analytics_tracking_id))
     ANALYTICS_TRACKING_ID_XGOV: ((direct_debit_frontend_analytics_tracking_id_xgov))
-    CONNECTOR_URL: ((direct_debit_connector_url))
-    PRODUCTS_URL: ((products_url))
-    PUBLICAUTH_URL: ((publicauth_url))
     SENTRY_DSN: ((direct_debit_frontend_sentry_dsn))
     ENVIRONMENT: ((space))
-  routes:
-  - route: ((direct_debit_frontend_url))


### PR DESCRIPTION
This supports mapping of data provided by user-provided backing
services on PaaS to application environment variables required
by the application.
