### PR TITLE
PP-6127: Bind app to PaaS secrets service

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -1,4 +1,8 @@
 env_vars:
-  CONNECTOR_URL: '."user-provided"[0].credentials.directdebit_connector_url'
-  ADMINUSERS_URL: '."user-provided"[0].credentials.adminusers_url'
-  PUBLICAUTH_URL: '."user-provided"[0].credentials.publicauth_url'
+  CONNECTOR_URL:              '.[][] | select(.name == "app-catalog")                         | .credentials.directdebit_connector_url'
+  ADMINUSERS_URL:             '.[][] | select(.name == "app-catalog")                         | .credentials.adminusers_url'
+  PUBLICAUTH_URL:             '.[][] | select(.name == "app-catalog")                         | .credentials.publicauth_url'
+  SENTRY_DSN:                 '.[][] | select(.name == "directdebit-frontend-secret-service") | .credentials.sentry_dsn'
+  ANALYTICS_TRACKING_ID:      '.[][] | select(.name == "directdebit-frontend-secret-service") | .credentials.analytics_tracking_id'
+  ANALYTICS_TRACKING_ID_XGOV: '.[][] | select(.name == "directdebit-frontend-secret-service") | .credentials.analytics_tracking_id_xgov'
+  SESSION_ENCRYPTION_KEY:     '.[][] | select(.name == "directdebit-frontend-secret-service") | .credentials.session_encryption_key'

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,12 +11,20 @@ applications:
   disk_quota: ((disk_quota))
   services:
     - app-catalog
+    - directdebit-frontend-secret-service
   command: npm start
   env:
     NODE_ENV: production
-    SESSION_ENCRYPTION_KEY: ((direct_debit_frontend_session_encryption_key))
     COOKIE_MAX_AGE: '10800000'
-    ANALYTICS_TRACKING_ID: ((direct_debit_frontend_analytics_tracking_id))
-    ANALYTICS_TRACKING_ID_XGOV: ((direct_debit_frontend_analytics_tracking_id_xgov))
-    SENTRY_DSN: ((direct_debit_frontend_sentry_dsn))
     ENVIRONMENT: ((space))
+
+    # Provided by directdebit-frontend-secret-service
+    SENTRY_DSN: ""
+    ANALYTICS_TRACKING_ID: ""
+    ANALYTICS_TRACKING_ID_XGOV: ""
+    SESSION_ENCRYPTION_KEY: ""
+ 
+    # Provided by app-catalog service
+    CONNECTOR_URL: ""
+    ADMINUSERS_URL: ""
+    PUBLICAUTH_URL: ""


### PR DESCRIPTION
## WHAT
Binds dd-frontend to secrets service added in alphagov/pay-omnibus#105
Adds environment variable mappings to `env-map.yml` to transpose VCAP_SERVICE data to application environment variables.