### PR TITLE
PP-6254 Add carbon-relay

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -2,6 +2,8 @@ env_vars:
   CONNECTOR_URL:              '.[][] | select(.name == "app-catalog")                         | .credentials.directdebit_connector_url'
   ADMINUSERS_URL:             '.[][] | select(.name == "app-catalog")                         | .credentials.adminusers_url'
   PUBLICAUTH_URL:             '.[][] | select(.name == "app-catalog")                         | .credentials.publicauth_url'
+  METRICS_HOST:               '.[][] | select(.name == "app-catalog")                         | .credentials.carbon_relay_route'
+  METRICS_PORT:               '.[][] | select(.name == "app-catalog")                         | .credentials.carbon_relay_port'
   SENTRY_DSN:                 '.[][] | select(.name == "directdebit-frontend-secret-service") | .credentials.sentry_dsn'
   ANALYTICS_TRACKING_ID:      '.[][] | select(.name == "directdebit-frontend-secret-service") | .credentials.analytics_tracking_id'
   ANALYTICS_TRACKING_ID_XGOV: '.[][] | select(.name == "directdebit-frontend-secret-service") | .credentials.analytics_tracking_id_xgov'

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,8 +23,10 @@ applications:
     ANALYTICS_TRACKING_ID: ""
     ANALYTICS_TRACKING_ID_XGOV: ""
     SESSION_ENCRYPTION_KEY: ""
- 
+
     # Provided by app-catalog service
     CONNECTOR_URL: ""
     ADMINUSERS_URL: ""
     PUBLICAUTH_URL: ""
+    METRICS_HOST: ""
+    METRICS_PORT: ""


### PR DESCRIPTION
Set the METRICS_HOST and METRICS_PORT from the app-catalog to send
metrics to the carbon-relay app.
