### PR TITLE
PP-6254 Update engine version for PaaS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": "12.14.1"
+    "node": "12.16.1"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
PaaS no longer support engine version 12.14.1 so updating to the latest
12.* version that is supported. This setting is currently only used by
cf to select an appropriate buildpack.
