### PR TITLE
BAU remove govuk pay label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - dependencies
-  - govuk-pay
   - javascript
   ignore:
   - dependency-name: node


### PR DESCRIPTION
## WHAT
- remove label from dependabot labels. since we no longer merge dependabot PRs for dd apps, we don't want them to appear on the list either.
